### PR TITLE
Fix release artifact download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: wisp-*
 
       - name: Create Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Docker build-push-action uploads a metadata artifact that causes the release download step to fail. Filter to only download wisp-* artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved artifact filtering in the release process to ensure only relevant artifacts are included during release creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->