### PR TITLE
Add NIP-17 and NIP-59 to supported NIPs list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For more options, see `wisp.toml.example`.
 
 ## Features
 
-* NIPs: 1, 2, 9, 11, 13, 16, 22, 33, 40, 42, 45, 50, 65, 70, 77, 86
+* NIPs: 1, 2, 9, 11, 13, 16, 17, 22, 33, 40, 42, 45, 50, 59, 65, 70, 77, 86
 * LMDB storage (no external database)
 * Spider mode for syncing events from external relays
 * Import/export to JSONL

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -41,7 +41,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
         try writeJsonString(w, contact);
     }
 
-    try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,22,33,40,42,45,50,65,70,77,86]");
+    try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,17,22,33,40,42,45,50,59,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
     try w.writeAll(",\"version\":\"0.2.0\"");
 


### PR DESCRIPTION
libnostr-z already implements NIP-17 (Private DMs) and NIP-59 (Gift Wrap), including kind 1059 (gift wrap) and kind 13 (seal) handling. These were missing from both the NIP-11 relay info document and the README.

This enables relay-level support for LEMON-00/01 (Lemonwire, my thing) and MIP-00 through MIP-03 (Marmot Protocol), which depend on gift-wrap for private message delivery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added support for Nostr Implementation Possibilities (NIP) 17 and NIP 59 in the service's protocol implementation list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->