### PR TITLE
Pin websocket dependency to a fixed commit

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,9 +3,12 @@
     .version = "0.2.0",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
-        // websocket client for spider outbound connections
+        // websocket client for spider outbound connections.
+        // Pinned to a fixed commit (not refs/heads/master) so builds stay
+        // reproducible; master has since moved to Zig 0.16 APIs that do not
+        // compile under the Zig version this project targets.
         .websocket = .{
-            .url = "https://github.com/karlseguin/websocket.zig/archive/refs/heads/master.tar.gz",
+            .url = "https://github.com/karlseguin/websocket.zig/archive/97fefafa59cc78ce177cff540b8685cd7f699276.tar.gz",
             .hash = "websocket-0.1.0-ZPISdRlzAwBB_Bz2UMMqxYqF6YEVTIBoFsbzwPUJTHIc",
         },
         .nostr = .{


### PR DESCRIPTION
## Problem

`build.zig.zon` fetched the `websocket` dependency from `refs/heads/master`, a moving ref. That branch has since advanced to Zig 0.16 APIs (`@Tuple`, `std.Io.Mutex`, `std.Io.net`), so the recorded hash no longer matches and `zig build` fails with a hash mismatch on a clean checkout:

```
error: hash mismatch: manifest declares 'websocket-0.1.0-ZPISdRlzAwBB...'
but the fetched package has 'websocket-0.1.0-ZPISdV_aBACU...'
```

## Fix

Pin `websocket` to commit `97fefaf` (the master commit from when this hash was recorded). That archive hashes to the exact value already declared, so the hash is unchanged — this only stops the URL from drifting. Builds are now reproducible.

Verified with a clean-cache `zig build -Doptimize=ReleaseFast` on Zig 0.15.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated websocket dependency to use a pinned commit version instead of the master branch, ensuring consistent builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->