### PR TITLE
Bump version to 0.2.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.2.0",
+    .version = "0.2.2",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket client for spider outbound connections.

--- a/src/main.zig
+++ b/src/main.zig
@@ -147,7 +147,7 @@ pub fn main() !void {
     try nostr.init();
     defer nostr.cleanup();
 
-    std.log.info("Wisp v0.2.0 starting", .{});
+    std.log.info("Wisp v0.2.2 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s}", .{config.storage_path});
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,22,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.2.0\"");
+    try w.writeAll(",\"version\":\"0.2.2\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Updates the in-code version from `0.2.0` to `0.2.2` so it matches the release tag. These strings had not been bumped for the v0.2.1 or v0.2.2 tags.

- `build.zig.zon` — `.version`
- `src/main.zig` — startup log line
- `src/nip11.zig` — `version` field in the NIP-11 relay info document (advertised to clients)

Verified: clean `zig build` succeeds and the binary logs `Wisp v0.2.2 starting`.

After merge, the `v0.2.2` tag should be re-cut on the new `main` so the release ships the corrected version.