### PR TITLE
Migrate to Zig 0.16

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Clone nostr-bench
-        run: git clone --depth 1 --branch v0.1.0 https://github.com/privkeyio/nostr-bench ../nostr-bench
+        run: git clone --depth 1 --branch v0.2.0 https://github.com/privkeyio/nostr-bench ../nostr-bench
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y liblmdb-dev libsecp256k1-dev libssl-dev netcat-openbsd

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build wisp
         run: zig build -Doptimize=ReleaseSafe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Setup Zig
         run: |
-          curl -L https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.15.2" >> $GITHUB_PATH
+          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
+          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
 
       - name: Build
         run: zig build
@@ -44,8 +44,8 @@ jobs:
 
       - name: Setup Zig
         run: |
-          curl -L https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.15.2" >> $GITHUB_PATH
+          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
+          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
 
       - name: Install nak (nostr test client)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build
         run: zig build -Doptimize=ReleaseFast

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ wisp.toml
 wisp-db-test/
 benchmark/results.json
 book/
+zig-pkg/

--- a/build.zig
+++ b/build.zig
@@ -32,7 +32,7 @@ pub fn build(b: *std.Build) void {
 
     // System libraries
     exe.root_module.linkSystemLibrary("lmdb", .{});
-    exe.linkLibC();
+    exe.root_module.link_libc = true;
 
     b.installArtifact(exe);
 
@@ -50,10 +50,27 @@ pub fn build(b: *std.Build) void {
         }),
     });
     test_lmdb.root_module.linkSystemLibrary("lmdb", .{});
-    test_lmdb.linkLibC();
+    test_lmdb.root_module.link_libc = true;
     b.installArtifact(test_lmdb);
 
     const run_test_lmdb = b.addRunArtifact(test_lmdb);
     run_test_lmdb.step.dependOn(b.getInstallStep());
     b.step("test-lmdb", "Test LMDB bindings").dependOn(&run_test_lmdb.step);
+
+    const unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "nostr", .module = nostr.module("nostr") },
+                .{ .name = "websocket", .module = websocket.module("websocket") },
+            },
+        }),
+    });
+    unit_tests.root_module.linkSystemLibrary("lmdb", .{});
+    unit_tests.root_module.link_libc = true;
+
+    const run_unit_tests = b.addRunArtifact(unit_tests);
+    b.step("test", "Run unit tests").dependOn(&run_unit_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,17 +3,16 @@
     .version = "0.2.2",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
-        // websocket client for spider outbound connections.
-        // Pinned to a fixed commit (not refs/heads/master) so builds stay
-        // reproducible; master has since moved to Zig 0.16 APIs that do not
-        // compile under the Zig version this project targets.
+        // websocket.zig: client for spider outbound connections and the
+        // epoll worker-pool server. Pinned to a fixed commit for reproducible
+        // builds.
         .websocket = .{
-            .url = "https://github.com/karlseguin/websocket.zig/archive/97fefafa59cc78ce177cff540b8685cd7f699276.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdRlzAwBB_Bz2UMMqxYqF6YEVTIBoFsbzwPUJTHIc",
+            .url = "https://github.com/karlseguin/websocket.zig/archive/6d309f7a9790030f2fc070323b5defc64a15c13b.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdV_aBACU9pGuvrTQ2z8uxz_Sp8JnJgQaiGKQIx1l",
         },
         .nostr = .{
-            .url = "https://github.com/privkeyio/libnostr-z/archive/3322715dc9c75b4cb50087c14dad8b7996b31a82.tar.gz",
-            .hash = "nostr-0.1.8-JY6OcJ72CADZ8IIi9NQYOFFjj5Rldf-17TXKwv-Y9lY4",
+            .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.0.tar.gz",
+            .hash = "nostr-0.3.0-JY6OcJJ0DwDrcooJo6viPaiDg6ohNPie0wV10XykgQPE",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.2.2",
+    .version = "0.3.0",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the

--- a/src/config.zig
+++ b/src/config.zig
@@ -1,4 +1,10 @@
 const std = @import("std");
+const nostr = @import("nostr.zig");
+
+fn getenv(name: [*:0]const u8) ?[]const u8 {
+    const v = std.c.getenv(name) orelse return null;
+    return std.mem.sliceTo(v, 0);
+}
 
 pub const Config = struct {
     host: []const u8,
@@ -97,12 +103,10 @@ pub const Config = struct {
     pub fn load(allocator: std.mem.Allocator, path: []const u8) !Config {
         var config = defaults();
         config._allocator = allocator;
-        config._allocated = .{};
+        config._allocated = .empty;
 
-        const file = try std.fs.cwd().openFile(path, .{});
-        defer file.close();
-
-        const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+        const io = nostr.io.io();
+        const content = try std.Io.Dir.cwd().readFileAlloc(io, path, allocator, .limited(1024 * 1024));
         defer allocator.free(content);
 
         var section: []const u8 = "";
@@ -247,55 +251,55 @@ pub const Config = struct {
     }
 
     pub fn loadEnv(self: *Config) void {
-        if (std.posix.getenv("WISP_HOST")) |v| self.host = v;
-        if (std.posix.getenv("WISP_PORT")) |v| {
+        if (getenv("WISP_HOST")) |v| self.host = v;
+        if (getenv("WISP_PORT")) |v| {
             self.port = std.fmt.parseInt(u16, v, 10) catch self.port;
         }
-        if (std.posix.getenv("WISP_RELAY_NAME")) |v| self.name = v;
-        if (std.posix.getenv("WISP_STORAGE_PATH")) |v| self.storage_path = v;
-        if (std.posix.getenv("WISP_MAX_CONNECTIONS")) |v| {
+        if (getenv("WISP_RELAY_NAME")) |v| self.name = v;
+        if (getenv("WISP_STORAGE_PATH")) |v| self.storage_path = v;
+        if (getenv("WISP_MAX_CONNECTIONS")) |v| {
             self.max_connections = std.fmt.parseInt(u32, v, 10) catch self.max_connections;
         }
-        if (std.posix.getenv("WISP_AUTH_REQUIRED")) |v| {
+        if (getenv("WISP_AUTH_REQUIRED")) |v| {
             self.auth_required = std.mem.eql(u8, v, "true") or std.mem.eql(u8, v, "1");
         }
-        if (std.posix.getenv("WISP_AUTH_TO_WRITE")) |v| {
+        if (getenv("WISP_AUTH_TO_WRITE")) |v| {
             self.auth_to_write = std.mem.eql(u8, v, "true") or std.mem.eql(u8, v, "1");
         }
-        if (std.posix.getenv("WISP_RELAY_URL")) |v| self.relay_url = v;
-        if (std.posix.getenv("WISP_TRUST_PROXY")) |v| {
+        if (getenv("WISP_RELAY_URL")) |v| self.relay_url = v;
+        if (getenv("WISP_TRUST_PROXY")) |v| {
             self.trust_proxy = std.mem.eql(u8, v, "true") or std.mem.eql(u8, v, "1");
         }
-        if (std.posix.getenv("WISP_MAX_CONNECTIONS_PER_IP")) |v| {
+        if (getenv("WISP_MAX_CONNECTIONS_PER_IP")) |v| {
             self.max_connections_per_ip = std.fmt.parseInt(u32, v, 10) catch self.max_connections_per_ip;
         }
-        if (std.posix.getenv("WISP_EVENTS_PER_MINUTE")) |v| {
+        if (getenv("WISP_EVENTS_PER_MINUTE")) |v| {
             self.events_per_minute = std.fmt.parseInt(u32, v, 10) catch self.events_per_minute;
         }
-        if (std.posix.getenv("WISP_IDLE_SECONDS")) |v| {
+        if (getenv("WISP_IDLE_SECONDS")) |v| {
             self.idle_seconds = std.fmt.parseInt(u32, v, 10) catch self.idle_seconds;
         }
-        if (std.posix.getenv("WISP_IP_WHITELIST")) |v| self.ip_whitelist = v;
-        if (std.posix.getenv("WISP_IP_BLACKLIST")) |v| self.ip_blacklist = v;
-        if (std.posix.getenv("WISP_SPIDER_ENABLED")) |v| {
+        if (getenv("WISP_IP_WHITELIST")) |v| self.ip_whitelist = v;
+        if (getenv("WISP_IP_BLACKLIST")) |v| self.ip_blacklist = v;
+        if (getenv("WISP_SPIDER_ENABLED")) |v| {
             self.spider_enabled = std.mem.eql(u8, v, "true") or std.mem.eql(u8, v, "1");
         }
-        if (std.posix.getenv("WISP_SPIDER_RELAYS")) |v| self.spider_relays = v;
-        if (std.posix.getenv("WISP_SPIDER_ADMIN")) |v| self.spider_admin = v;
-        if (std.posix.getenv("WISP_SPIDER_PUBKEYS")) |v| self.spider_pubkeys = v;
-        if (std.posix.getenv("WISP_SPIDER_SYNC_INTERVAL")) |v| {
+        if (getenv("WISP_SPIDER_RELAYS")) |v| self.spider_relays = v;
+        if (getenv("WISP_SPIDER_ADMIN")) |v| self.spider_admin = v;
+        if (getenv("WISP_SPIDER_PUBKEYS")) |v| self.spider_pubkeys = v;
+        if (getenv("WISP_SPIDER_SYNC_INTERVAL")) |v| {
             self.spider_sync_interval = std.fmt.parseInt(u32, v, 10) catch self.spider_sync_interval;
         }
-        if (std.posix.getenv("WISP_NEGENTROPY_ENABLED")) |v| {
+        if (getenv("WISP_NEGENTROPY_ENABLED")) |v| {
             self.negentropy_enabled = std.mem.eql(u8, v, "true") or std.mem.eql(u8, v, "1");
         }
-        if (std.posix.getenv("WISP_NEGENTROPY_MAX_SYNC_EVENTS")) |v| {
+        if (getenv("WISP_NEGENTROPY_MAX_SYNC_EVENTS")) |v| {
             self.negentropy_max_sync_events = std.fmt.parseInt(u32, v, 10) catch self.negentropy_max_sync_events;
         }
-        if (std.posix.getenv("WISP_MIN_POW_DIFFICULTY")) |v| {
+        if (getenv("WISP_MIN_POW_DIFFICULTY")) |v| {
             self.min_pow_difficulty = std.fmt.parseInt(u8, v, 10) catch self.min_pow_difficulty;
         }
-        if (std.posix.getenv("WISP_ADMIN_PUBKEYS")) |v| self.admin_pubkeys = v;
+        if (getenv("WISP_ADMIN_PUBKEYS")) |v| self.admin_pubkeys = v;
     }
 
     pub fn deinit(self: *Config) void {

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -47,7 +47,7 @@ pub const Connection = struct {
     deinitialized: bool = false,
 
     pub fn init(self: *Connection, backing_allocator: std.mem.Allocator, id: u64) void {
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
         self.id = id;
         self.backing_allocator = backing_allocator;
         self.arena = std.heap.ArenaAllocator.init(backing_allocator);
@@ -63,7 +63,7 @@ pub const Connection = struct {
         self.direct_write_ctx = null;
         self.direct_write_failed = null;
         self.socket_handle = null;
-        std.crypto.random.bytes(&self.auth_challenge);
+        nostr.io.randomBytes(&self.auth_challenge);
         self.authenticated_pubkeys = std.AutoHashMap([32]u8, void).init(self.arena.allocator());
         self.challenge_sent = false;
         self.write_queue = WriteQueue.init(backing_allocator);
@@ -138,7 +138,8 @@ pub const Connection = struct {
 
     pub fn shutdown(self: *Connection) void {
         if (self.socket_handle) |handle| {
-            posix.shutdown(handle, .both) catch {};
+            const stream = std.Io.net.Stream{ .socket = .{ .handle = handle, .address = undefined } };
+            stream.shutdown(nostr.io.io(), .both) catch {};
             self.socket_handle = null;
         }
     }
@@ -175,7 +176,7 @@ pub const Connection = struct {
         try self.subscriptions.put(sub_id_copy, .{
             .id = sub_id_copy,
             .filters = filters_copy,
-            .created_at = std.time.timestamp(),
+            .created_at = nostr.io.timestamp(),
         });
     }
 
@@ -217,12 +218,12 @@ pub const Connection = struct {
     }
 
     pub fn touch(self: *Connection) void {
-        self.last_activity = std.time.timestamp();
+        self.last_activity = nostr.io.timestamp();
     }
 
     pub fn checkEventRateLimit(self: *Connection, max_events_per_minute: u32) bool {
         if (max_events_per_minute == 0) return true;
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
         const window_start = now - 60;
         var count: u32 = 0;
         var i: u8 = 0;
@@ -236,7 +237,7 @@ pub const Connection = struct {
     }
 
     pub fn recordEvent(self: *Connection) void {
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
         self.event_timestamps[self.event_ts_head] = now;
         self.event_ts_head +%= 1;
         if (self.event_ts_count < 255) {

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -215,7 +215,7 @@ pub const Handler = struct {
     }
 
     fn validateMessageStructure(message: []const u8) bool {
-        const trimmed = std.mem.trimRight(u8, message, " \t\r\n");
+        const trimmed = std.mem.trimEnd(u8, message, " \t\r\n");
         if (trimmed.len < 5) return false;
         if (trimmed[0] != '[') return false;
         if (trimmed[trimmed.len - 1] != ']') return false;
@@ -271,7 +271,7 @@ pub const Handler = struct {
             return;
         }
 
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
         const created = event.createdAt();
 
         if (created > now + self.config.max_future_seconds) {
@@ -567,7 +567,7 @@ pub const Handler = struct {
             return;
         }
 
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
         const created = event.createdAt();
         const time_diff = if (now > created) now - created else created - now;
         if (time_diff > 600) {

--- a/src/lmdb.zig
+++ b/src/lmdb.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const nostr = @import("nostr.zig");
 
 const c = @cImport({
     @cInclude("lmdb.h");
@@ -45,8 +46,11 @@ pub const Lmdb = struct {
 
         _ = c.mdb_env_set_maxreaders(env, 512);
 
+        const io = nostr.io.io();
+        const cwd = std.Io.Dir.cwd();
+
         if (std.fs.path.dirname(path)) |parent| {
-            std.fs.cwd().makePath(parent) catch {};
+            cwd.createDirPath(io, parent) catch {};
         }
 
         const path_z = try allocator.dupeZ(u8, path);
@@ -59,18 +63,18 @@ pub const Lmdb = struct {
             return error.EnvOpen;
         }
 
-        const data_file = std.fs.cwd().openFile(path, .{}) catch null;
+        const data_file = cwd.openFile(io, path, .{}) catch null;
         if (data_file) |f| {
-            f.chmod(0o600) catch |err| std.log.warn("chmod data file failed: {}", .{err});
-            f.close();
+            f.setPermissions(io, @enumFromInt(0o600)) catch |err| std.log.warn("chmod data file failed: {}", .{err});
+            f.close(io);
         }
 
         const lock_path = try std.fmt.allocPrint(allocator, "{s}-lock", .{path});
         defer allocator.free(lock_path);
-        const lock_file = std.fs.cwd().openFile(lock_path, .{}) catch null;
+        const lock_file = cwd.openFile(io, lock_path, .{}) catch null;
         if (lock_file) |f| {
-            f.chmod(0o600) catch |err| std.log.warn("chmod lock file failed: {}", .{err});
-            f.close();
+            f.setPermissions(io, @enumFromInt(0o600)) catch |err| std.log.warn("chmod lock file failed: {}", .{err});
+            f.close(io);
         }
 
         return .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -284,7 +284,10 @@ fn runImport(allocator: std.mem.Allocator, db_path: []const u8) !void {
     var read_buf: [65536]u8 = undefined;
 
     while (true) {
-        const bytes_read = std.posix.read(std.posix.STDIN_FILENO, &read_buf) catch break;
+        const bytes_read = std.posix.read(std.posix.STDIN_FILENO, &read_buf) catch |err| {
+            printStatus(stderr_file, "Import aborted: read error: {}\n", .{err});
+            return err;
+        };
         if (bytes_read == 0) break;
 
         for (read_buf[0..bytes_read]) |byte| {
@@ -378,8 +381,14 @@ fn runExport(allocator: std.mem.Allocator, db_path: []const u8) !void {
     var exported: u64 = 0;
 
     while (try iter.next()) |json| {
-        stdout_file.writeStreamingAll(io, json) catch return;
-        stdout_file.writeStreamingAll(io, "\n") catch return;
+        stdout_file.writeStreamingAll(io, json) catch |err| {
+            printStatus(stderr_file, "Export aborted: write error: {}\n", .{err});
+            return err;
+        };
+        stdout_file.writeStreamingAll(io, "\n") catch |err| {
+            printStatus(stderr_file, "Export aborted: write error: {}\n", .{err});
+            return err;
+        };
         exported += 1;
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -154,7 +154,7 @@ pub fn main(init: std.process.Init.Minimal) !void {
     try nostr.init();
     defer nostr.cleanup();
 
-    std.log.info("Wisp v0.2.2 starting", .{});
+    std.log.info("Wisp v0.3.0 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s}", .{config.storage_path});
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -22,7 +22,7 @@ const Nip86Handler = @import("nip86.zig").Nip86Handler;
 var g_server: ?*TcpServer = null;
 var g_shutdown: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
-fn signalHandler(_: c_int) callconv(std.builtin.CallingConvention.c) void {
+fn signalHandler(_: std.posix.SIG) callconv(std.builtin.CallingConvention.c) void {
     g_shutdown.store(true, .release);
 }
 
@@ -30,6 +30,10 @@ fn sendCallback(conn_id: u64, data: []const u8) void {
     if (g_server) |s| {
         s.send(conn_id, data);
     }
+}
+
+fn stdFile(handle: std.posix.fd_t) std.Io.File {
+    return .{ .handle = handle, .flags = .{ .nonblocking = false } };
 }
 
 const Command = enum {
@@ -67,16 +71,19 @@ fn printHelp() void {
         \\  wisp export > backup.jsonl            Export all events
         \\
     ;
-    const stdout = std.fs.File{ .handle = std.posix.STDOUT_FILENO };
-    stdout.writeAll(help) catch {};
+    stdFile(std.posix.STDOUT_FILENO).writeStreamingAll(nostr.io.io(), help) catch {};
 }
 
-pub fn main() !void {
+pub fn main(init: std.process.Init.Minimal) !void {
     // Use c_allocator for production - better memory behavior than GPA
     const allocator = std.heap.c_allocator;
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    var arg_it = std.process.Args.Iterator.init(init.args);
+    defer arg_it.deinit();
+    var arg_list: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer arg_list.deinit(allocator);
+    while (arg_it.next()) |a| try arg_list.append(allocator, a);
+    const args = arg_list.items;
 
     var cmd = Command.relay;
     var config_path: ?[]const u8 = null;
@@ -205,6 +212,15 @@ pub fn main() !void {
     std.posix.sigaction(std.posix.SIG.INT, &sa, null);
     std.posix.sigaction(std.posix.SIG.TERM, &sa, null);
 
+    // Ignore SIGPIPE: a client disconnecting mid-write must surface as an EPIPE
+    // error (handled by the write paths), not terminate the process.
+    const ignore_sa = std.posix.Sigaction{
+        .handler = .{ .handler = std.posix.SIG.IGN },
+        .mask = std.posix.sigemptyset(),
+        .flags = 0,
+    };
+    std.posix.sigaction(std.posix.SIG.PIPE, &ignore_sa, null);
+
     const cleanup_thread = std.Thread.spawn(.{}, storeCleanupThread, .{ &store, &config, &g_shutdown, &server.conn_limiter, &event_limiter }) catch null;
     defer if (cleanup_thread) |t| t.join();
 
@@ -221,7 +237,7 @@ fn storeCleanupThread(store: *Store, config: *const Config, shutdown: *std.atomi
     var checks: u64 = 0;
 
     while (!shutdown.load(.acquire)) {
-        std.Thread.sleep(check_interval_ns);
+        std.Io.sleep(nostr.io.io(), .{ .nanoseconds = check_interval_ns }, .awake) catch {};
         if (shutdown.load(.acquire)) break;
         checks += 1;
 
@@ -256,20 +272,19 @@ fn runImport(allocator: std.mem.Allocator, db_path: []const u8) !void {
     var store = try Store.init(allocator, &lmdb);
     defer store.deinit();
 
-    const stdin_file = std.fs.File{ .handle = std.posix.STDIN_FILENO };
-    const stderr_file = std.fs.File{ .handle = std.posix.STDERR_FILENO };
+    const stderr_file = stdFile(std.posix.STDERR_FILENO);
 
     var imported: u64 = 0;
     var failed: u64 = 0;
     var duplicates: u64 = 0;
 
-    var line_list: std.ArrayListUnmanaged(u8) = .{};
+    var line_list: std.ArrayListUnmanaged(u8) = .empty;
     defer line_list.deinit(allocator);
 
     var read_buf: [65536]u8 = undefined;
 
     while (true) {
-        const bytes_read = stdin_file.read(&read_buf) catch break;
+        const bytes_read = std.posix.read(std.posix.STDIN_FILENO, &read_buf) catch break;
         if (bytes_read == 0) break;
 
         for (read_buf[0..bytes_read]) |byte| {
@@ -339,10 +354,10 @@ fn processImportLine(allocator: std.mem.Allocator, store: *Store, line: []const 
     }
 }
 
-fn printStatus(file: std.fs.File, comptime fmt: []const u8, args: anytype) void {
+fn printStatus(file: std.Io.File, comptime fmt: []const u8, args: anytype) void {
     var buf: [256]u8 = undefined;
     const msg = std.fmt.bufPrint(&buf, fmt, args) catch return;
-    file.writeAll(msg) catch {};
+    file.writeStreamingAll(nostr.io.io(), msg) catch {};
 }
 
 fn runExport(allocator: std.mem.Allocator, db_path: []const u8) !void {
@@ -352,8 +367,9 @@ fn runExport(allocator: std.mem.Allocator, db_path: []const u8) !void {
     var store = try Store.init(allocator, &lmdb);
     defer store.deinit();
 
-    const stdout_file = std.fs.File{ .handle = std.posix.STDOUT_FILENO };
-    const stderr_file = std.fs.File{ .handle = std.posix.STDERR_FILENO };
+    const io = nostr.io.io();
+    const stdout_file = stdFile(std.posix.STDOUT_FILENO);
+    const stderr_file = stdFile(std.posix.STDERR_FILENO);
 
     const empty_filters = [_]nostr.Filter{};
     var iter = try store.query(&empty_filters, std.math.maxInt(u32));
@@ -362,10 +378,15 @@ fn runExport(allocator: std.mem.Allocator, db_path: []const u8) !void {
     var exported: u64 = 0;
 
     while (try iter.next()) |json| {
-        stdout_file.writeAll(json) catch return;
-        stdout_file.writeAll("\n") catch return;
+        stdout_file.writeStreamingAll(io, json) catch return;
+        stdout_file.writeStreamingAll(io, "\n") catch return;
         exported += 1;
     }
 
     printStatus(stderr_file, "Exported {d} events\n", .{exported});
+}
+
+test {
+    _ = @import("rate_limiter.zig");
+    _ = @import("write_queue.zig");
 }

--- a/src/management_store.zig
+++ b/src/management_store.zig
@@ -3,6 +3,7 @@ const Lmdb = @import("lmdb.zig").Lmdb;
 const Txn = @import("lmdb.zig").Txn;
 const Dbi = @import("lmdb.zig").Dbi;
 const Cursor = @import("lmdb.zig").Cursor;
+const nostr = @import("nostr.zig");
 
 pub const ManagementStore = struct {
     lmdb: *Lmdb,
@@ -15,7 +16,7 @@ pub const ManagementStore = struct {
     blocked_ips: Dbi,
     relay_settings: Dbi,
 
-    mutex: std.Thread.Mutex,
+    mutex: std.Io.Mutex,
 
     pub fn init(allocator: std.mem.Allocator, lmdb: *Lmdb) !ManagementStore {
         var txn = try lmdb.beginTxn(false);
@@ -39,13 +40,14 @@ pub const ManagementStore = struct {
             .allowed_kinds = allowed_kinds,
             .blocked_ips = blocked_ips,
             .relay_settings = relay_settings,
-            .mutex = .{},
+            .mutex = .init,
         };
     }
 
     pub fn banPubkey(self: *ManagementStore, pubkey: *const [32]u8, reason: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
@@ -54,8 +56,9 @@ pub const ManagementStore = struct {
     }
 
     pub fn unbanPubkey(self: *ManagementStore, pubkey: *const [32]u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
@@ -76,7 +79,7 @@ pub const ManagementStore = struct {
         var cursor = try txn.cursor(self.banned_pubkeys);
         defer cursor.close();
 
-        var list: std.ArrayListUnmanaged(PubkeyEntry) = .{};
+        var list: std.ArrayListUnmanaged(PubkeyEntry) = .empty;
         errdefer {
             for (list.items) |*e| e.deinit(allocator);
             list.deinit(allocator);
@@ -101,8 +104,9 @@ pub const ManagementStore = struct {
     }
 
     pub fn allowPubkey(self: *ManagementStore, pubkey: *const [32]u8, reason: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
@@ -111,8 +115,9 @@ pub const ManagementStore = struct {
     }
 
     pub fn disallowPubkey(self: *ManagementStore, pubkey: *const [32]u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
@@ -141,7 +146,7 @@ pub const ManagementStore = struct {
         var cursor = try txn.cursor(self.allowed_pubkeys);
         defer cursor.close();
 
-        var list: std.ArrayListUnmanaged(PubkeyEntry) = .{};
+        var list: std.ArrayListUnmanaged(PubkeyEntry) = .empty;
         errdefer {
             for (list.items) |*e| e.deinit(allocator);
             list.deinit(allocator);
@@ -166,8 +171,9 @@ pub const ManagementStore = struct {
     }
 
     pub fn banEvent(self: *ManagementStore, event_id: *const [32]u8, reason: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
@@ -176,8 +182,9 @@ pub const ManagementStore = struct {
     }
 
     pub fn unbanEvent(self: *ManagementStore, event_id: *const [32]u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
@@ -198,7 +205,7 @@ pub const ManagementStore = struct {
         var cursor = try txn.cursor(self.banned_events);
         defer cursor.close();
 
-        var list: std.ArrayListUnmanaged(EventEntry) = .{};
+        var list: std.ArrayListUnmanaged(EventEntry) = .empty;
         errdefer {
             for (list.items) |*e| e.deinit(allocator);
             list.deinit(allocator);
@@ -223,8 +230,9 @@ pub const ManagementStore = struct {
     }
 
     pub fn allowKind(self: *ManagementStore, kind: i32) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
@@ -234,8 +242,9 @@ pub const ManagementStore = struct {
     }
 
     pub fn disallowKind(self: *ManagementStore, kind: i32) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
@@ -267,7 +276,7 @@ pub const ManagementStore = struct {
         var cursor = try txn.cursor(self.allowed_kinds);
         defer cursor.close();
 
-        var list: std.ArrayListUnmanaged(i32) = .{};
+        var list: std.ArrayListUnmanaged(i32) = .empty;
         errdefer list.deinit(allocator);
 
         var entry = try cursor.get(.first);
@@ -284,8 +293,9 @@ pub const ManagementStore = struct {
     }
 
     pub fn blockIp(self: *ManagementStore, ip: []const u8, reason: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
@@ -294,8 +304,9 @@ pub const ManagementStore = struct {
     }
 
     pub fn unblockIp(self: *ManagementStore, ip: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
@@ -325,7 +336,7 @@ pub const ManagementStore = struct {
         var cursor = try txn.cursor(self.blocked_ips);
         defer cursor.close();
 
-        var list: std.ArrayListUnmanaged(IpEntry) = .{};
+        var list: std.ArrayListUnmanaged(IpEntry) = .empty;
         errdefer {
             for (list.items) |*e| e.deinit(allocator);
             list.deinit(allocator);
@@ -348,8 +359,9 @@ pub const ManagementStore = struct {
     }
 
     pub fn setRelaySetting(self: *ManagementStore, key: []const u8, value: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.2.2\"");
+    try w.writeAll(",\"version\":\"0.3.0\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});

--- a/src/nip86.zig
+++ b/src/nip86.zig
@@ -175,7 +175,7 @@ pub const Nip86Handler = struct {
         const entries = self.mgmt_store.listBannedEvents(self.allocator) catch return nip86.Response.internalError();
         defer ManagementStore.freeEventEntries(entries, self.allocator);
 
-        var buf: std.ArrayListUnmanaged(u8) = .{};
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
         defer buf.deinit(self.allocator);
 
         buf.appendSlice(self.allocator, "{\"result\":[") catch return nip86.Response.internalError();
@@ -245,7 +245,7 @@ pub const Nip86Handler = struct {
         const kinds = self.mgmt_store.listAllowedKinds(self.allocator) catch return nip86.Response.internalError();
         defer self.allocator.free(kinds);
 
-        var buf: std.ArrayListUnmanaged(u8) = .{};
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
         defer buf.deinit(self.allocator);
 
         buf.appendSlice(self.allocator, "{\"result\":[") catch return nip86.Response.internalError();
@@ -281,7 +281,7 @@ pub const Nip86Handler = struct {
         const entries = self.mgmt_store.listBlockedIps(self.allocator) catch return nip86.Response.internalError();
         defer ManagementStore.freeIpEntries(entries, self.allocator);
 
-        var buf: std.ArrayListUnmanaged(u8) = .{};
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
         defer buf.deinit(self.allocator);
 
         buf.appendSlice(self.allocator, "{\"result\":[") catch return nip86.Response.internalError();
@@ -300,7 +300,7 @@ pub const Nip86Handler = struct {
     }
 
     fn formatPubkeyList(self: *Nip86Handler, entries: []const ManagementStore.PubkeyEntry) nip86.Response {
-        var buf: std.ArrayListUnmanaged(u8) = .{};
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
         defer buf.deinit(self.allocator);
 
         buf.appendSlice(self.allocator, "{\"result\":[") catch return nip86.Response.internalError();

--- a/src/nostr.zig
+++ b/src/nostr.zig
@@ -26,6 +26,7 @@ pub const crypto = nostr_lib.crypto;
 pub const bech32 = nostr_lib.bech32;
 pub const init = nostr_lib.init;
 pub const cleanup = nostr_lib.cleanup;
+pub const io = nostr_lib.io;
 
 pub const Auth = nostr_lib.Auth;
 pub const Replaceable = nostr_lib.Replaceable;

--- a/src/query_cache.zig
+++ b/src/query_cache.zig
@@ -1,11 +1,12 @@
 const std = @import("std");
+const nostr = @import("nostr.zig");
 
 pub const QueryCache = struct {
     allocator: std.mem.Allocator,
     entries: std.AutoHashMap(CacheKey, CacheEntry),
     access_order: std.ArrayListUnmanaged(CacheKey),
     max_entries: usize,
-    mutex: std.Thread.Mutex,
+    mutex: std.Io.Mutex,
     hits: u64 = 0,
     misses: u64 = 0,
     generation: u64 = 0,
@@ -28,9 +29,9 @@ pub const QueryCache = struct {
         return .{
             .allocator = allocator,
             .entries = std.AutoHashMap(CacheKey, CacheEntry).init(allocator),
-            .access_order = .{},
+            .access_order = .empty,
             .max_entries = MAX_ENTRIES,
-            .mutex = .{},
+            .mutex = .init,
         };
     }
 
@@ -47,12 +48,13 @@ pub const QueryCache = struct {
     }
 
     pub fn get(self: *QueryCache, kind: i32, limit: u32) ?[]const []const u8 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         const key = CacheKey{ .kind = kind, .limit = limit };
         if (self.entries.get(key)) |entry| {
-            const now = std.time.timestamp();
+            const now = nostr.io.timestamp();
             if (now - entry.timestamp <= TTL_SECONDS and entry.generation == self.generation) {
                 self.hits += 1;
                 return entry.results;
@@ -64,8 +66,9 @@ pub const QueryCache = struct {
     }
 
     pub fn put(self: *QueryCache, kind: i32, limit: u32, results: []const []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         const key = CacheKey{ .kind = kind, .limit = limit };
 
@@ -89,15 +92,16 @@ pub const QueryCache = struct {
         self.entries.put(key, .{
             .results = results_copy,
             .generation = self.generation,
-            .timestamp = std.time.timestamp(),
+            .timestamp = nostr.io.timestamp(),
         }) catch return;
 
         self.access_order.append(self.allocator, key) catch {};
     }
 
     pub fn invalidate(self: *QueryCache) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         self.generation +%= 1;
     }
 
@@ -129,8 +133,9 @@ pub const QueryCache = struct {
     }
 
     pub fn stats(self: *QueryCache) struct { hits: u64, misses: u64, entries: usize } {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         return .{
             .hits = self.hits,
             .misses = self.misses,

--- a/src/rate_limiter.zig
+++ b/src/rate_limiter.zig
@@ -42,7 +42,10 @@ pub const ConnectionLimiter = struct {
         return true;
     }
 
-    pub fn addConnection(self: *ConnectionLimiter, ip: []const u8) void {
+    /// Atomically check the per-IP limit and increment in one locked section.
+    /// Returns false (without incrementing) if the IP is already at the limit,
+    /// closing the canConnect/addConnection check-then-act race.
+    pub fn tryAcquireConnection(self: *ConnectionLimiter, ip: []const u8) bool {
         const io = nostr.io.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
@@ -50,17 +53,21 @@ pub const ConnectionLimiter = struct {
         const now = nostr.io.timestamp();
 
         if (self.ip_buckets.getPtr(ip)) |bucket| {
+            if (bucket.connection_count >= self.max_connections_per_ip) return false;
             bucket.connection_count += 1;
             bucket.last_activity = now;
-        } else {
-            const ip_copy = self.allocator.dupe(u8, ip) catch return;
-            self.ip_buckets.put(ip_copy, .{
-                .connection_count = 1,
-                .last_activity = now,
-            }) catch {
-                self.allocator.free(ip_copy);
-            };
+            return true;
         }
+
+        const ip_copy = self.allocator.dupe(u8, ip) catch return false;
+        self.ip_buckets.put(ip_copy, .{
+            .connection_count = 1,
+            .last_activity = now,
+        }) catch {
+            self.allocator.free(ip_copy);
+            return false;
+        };
+        return true;
     }
 
     pub fn removeConnection(self: *ConnectionLimiter, ip: []const u8) void {

--- a/src/rate_limiter.zig
+++ b/src/rate_limiter.zig
@@ -1,8 +1,9 @@
 const std = @import("std");
+const nostr = @import("nostr.zig");
 
 pub const ConnectionLimiter = struct {
     allocator: std.mem.Allocator,
-    mutex: std.Thread.Mutex,
+    mutex: std.Io.Mutex,
     ip_buckets: std.StringHashMap(IpBucket),
     max_connections_per_ip: u32,
     cleanup_interval_seconds: i64,
@@ -15,7 +16,7 @@ pub const ConnectionLimiter = struct {
     pub fn init(allocator: std.mem.Allocator, max_connections_per_ip: u32) ConnectionLimiter {
         return .{
             .allocator = allocator,
-            .mutex = .{},
+            .mutex = .init,
             .ip_buckets = std.StringHashMap(IpBucket).init(allocator),
             .max_connections_per_ip = max_connections_per_ip,
             .cleanup_interval_seconds = 300,
@@ -31,8 +32,9 @@ pub const ConnectionLimiter = struct {
     }
 
     pub fn canConnect(self: *ConnectionLimiter, ip: []const u8) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         if (self.ip_buckets.get(ip)) |bucket| {
             return bucket.connection_count < self.max_connections_per_ip;
@@ -41,10 +43,11 @@ pub const ConnectionLimiter = struct {
     }
 
     pub fn addConnection(self: *ConnectionLimiter, ip: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
 
         if (self.ip_buckets.getPtr(ip)) |bucket| {
             bucket.connection_count += 1;
@@ -61,8 +64,9 @@ pub const ConnectionLimiter = struct {
     }
 
     pub fn removeConnection(self: *ConnectionLimiter, ip: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         if (self.ip_buckets.getPtr(ip)) |bucket| {
             if (bucket.connection_count > 0) {
@@ -72,11 +76,12 @@ pub const ConnectionLimiter = struct {
     }
 
     pub fn cleanup(self: *ConnectionLimiter) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
-        const now = std.time.timestamp();
-        var to_remove: std.ArrayListUnmanaged([]const u8) = .{};
+        const now = nostr.io.timestamp();
+        var to_remove: std.ArrayListUnmanaged([]const u8) = .empty;
         defer to_remove.deinit(self.allocator);
 
         var iter = self.ip_buckets.iterator();
@@ -95,8 +100,9 @@ pub const ConnectionLimiter = struct {
     }
 
     pub fn getStats(self: *ConnectionLimiter) Stats {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         return .{
             .tracked_ips = self.ip_buckets.count(),
@@ -113,7 +119,7 @@ pub const IpFilter = struct {
     whitelist: std.StringHashMap(void),
     blacklist: std.StringHashMap(void),
     whitelist_enabled: bool,
-    mutex: std.Thread.Mutex,
+    mutex: std.Io.Mutex,
 
     pub fn init(allocator: std.mem.Allocator) IpFilter {
         return .{
@@ -121,7 +127,7 @@ pub const IpFilter = struct {
             .whitelist = std.StringHashMap(void).init(allocator),
             .blacklist = std.StringHashMap(void).init(allocator),
             .whitelist_enabled = false,
-            .mutex = .{},
+            .mutex = .init,
         };
     }
 
@@ -140,8 +146,9 @@ pub const IpFilter = struct {
     }
 
     pub fn loadWhitelist(self: *IpFilter, list: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         if (list.len == 0) return;
 
@@ -157,8 +164,9 @@ pub const IpFilter = struct {
     }
 
     pub fn loadBlacklist(self: *IpFilter, list: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         if (list.len == 0) return;
 
@@ -173,8 +181,9 @@ pub const IpFilter = struct {
     }
 
     pub fn isAllowed(self: *IpFilter, ip: []const u8) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         if (self.matchesPrefix(&self.blacklist, ip)) {
             return false;
@@ -261,7 +270,7 @@ test "normalizeIp" {
 
 pub const EventRateLimiter = struct {
     allocator: std.mem.Allocator,
-    mutex: std.Thread.Mutex,
+    mutex: std.Io.Mutex,
     ip_buckets: std.StringHashMap(EventBucket),
     events_per_minute: u32,
 
@@ -276,7 +285,7 @@ pub const EventRateLimiter = struct {
     pub fn init(allocator: std.mem.Allocator, events_per_minute: u32) EventRateLimiter {
         return .{
             .allocator = allocator,
-            .mutex = .{},
+            .mutex = .init,
             .ip_buckets = std.StringHashMap(EventBucket).init(allocator),
             .events_per_minute = events_per_minute,
         };
@@ -293,10 +302,11 @@ pub const EventRateLimiter = struct {
     pub fn checkAndRecord(self: *EventRateLimiter, ip: []const u8) bool {
         if (self.events_per_minute == 0) return true;
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
         const window_start = now - WINDOW_SIZE;
 
         if (self.ip_buckets.getPtr(ip)) |bucket| {
@@ -336,12 +346,13 @@ pub const EventRateLimiter = struct {
     }
 
     pub fn cleanup(self: *EventRateLimiter) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
         const window_start = now - WINDOW_SIZE;
-        var to_remove: std.ArrayListUnmanaged([]const u8) = .{};
+        var to_remove: std.ArrayListUnmanaged([]const u8) = .empty;
         defer to_remove.deinit(self.allocator);
 
         var iter = self.ip_buckets.iterator();

--- a/src/spider.zig
+++ b/src/spider.zig
@@ -8,6 +8,10 @@ const websocket = @import("websocket");
 const log = std.log.scoped(.spider);
 const negentropy = nostr.negentropy;
 
+fn milliTimestamp() i64 {
+    return @intCast(@divTrunc(nostr.io.nanoTimestamp(), std.time.ns_per_ms));
+}
+
 const BATCH_SIZE: usize = 20;
 const BATCH_CREATION_DELAY_MS: u64 = 500;
 const RECONNECT_DELAY_MS: u64 = 10_000;
@@ -25,9 +29,9 @@ pub const Spider = struct {
     broadcaster: *Broadcaster,
     running: std.atomic.Value(bool),
     global_shutdown: *std.atomic.Value(bool),
-    relays: std.StringArrayHashMap(RelayConn),
+    relays: std.StringArrayHashMapUnmanaged(RelayConn),
     follow_pubkeys: std.ArrayListUnmanaged([32]u8),
-    follow_mutex: std.Thread.Mutex,
+    follow_mutex: std.Io.Mutex,
     threads: std.ArrayListUnmanaged(std.Thread),
     ca_bundle: std.crypto.Certificate.Bundle,
 
@@ -45,14 +49,15 @@ pub const Spider = struct {
             .broadcaster = broadcaster,
             .running = std.atomic.Value(bool).init(false),
             .global_shutdown = global_shutdown,
-            .relays = std.StringArrayHashMap(RelayConn).init(allocator),
-            .follow_pubkeys = .{},
-            .follow_mutex = .{},
-            .threads = .{},
-            .ca_bundle = .{},
+            .relays = .empty,
+            .follow_pubkeys = .empty,
+            .follow_mutex = .init,
+            .threads = .empty,
+            .ca_bundle = .empty,
         };
 
-        try spider.ca_bundle.rescan(allocator);
+        const io = nostr.io.io();
+        try spider.ca_bundle.rescan(allocator, io, std.Io.Timestamp.now(io, .real));
 
         var relay_iter = std.mem.splitScalar(u8, config.spider_relays, ',');
         while (relay_iter.next()) |relay_url| {
@@ -60,7 +65,7 @@ pub const Spider = struct {
             if (trimmed.len == 0) continue;
 
             const url_copy = try allocator.dupe(u8, trimmed);
-            try spider.relays.put(url_copy, RelayConn.init(url_copy));
+            try spider.relays.put(allocator, url_copy, RelayConn.init(url_copy));
         }
 
         return spider;
@@ -71,7 +76,7 @@ pub const Spider = struct {
         for (self.relays.keys()) |key| {
             self.allocator.free(key);
         }
-        self.relays.deinit();
+        self.relays.deinit(self.allocator);
         self.follow_pubkeys.deinit(self.allocator);
         self.threads.deinit(self.allocator);
     }
@@ -112,7 +117,7 @@ pub const Spider = struct {
         var remaining = ms;
         while (remaining > 0 and self.shouldRun()) {
             const sleep_ms = @min(remaining, interval_ms);
-            std.Thread.sleep(sleep_ms * @as(u64, std.time.ns_per_ms));
+            std.Io.sleep(nostr.io.io(), .{ .nanoseconds = @intCast(sleep_ms * @as(u64, std.time.ns_per_ms)) }, .awake) catch {};
             remaining -|= sleep_ms;
         }
     }
@@ -134,8 +139,8 @@ pub const Spider = struct {
     }
 
     fn refreshFollowList(self: *Spider) void {
-        self.follow_mutex.lock();
-        defer self.follow_mutex.unlock();
+        self.follow_mutex.lockUncancelable(nostr.io.io());
+        defer self.follow_mutex.unlock(nostr.io.io());
 
         self.follow_pubkeys.clearRetainingCapacity();
 
@@ -145,9 +150,9 @@ pub const Spider = struct {
                 return;
             }
             log.info("No local kind 3 found, bootstrapping from remote relay...", .{});
-            self.follow_mutex.unlock();
+            self.follow_mutex.unlock(nostr.io.io());
             self.bootstrapKind3();
-            self.follow_mutex.lock();
+            self.follow_mutex.lockUncancelable(nostr.io.io());
             if (self.loadKind3FollowList()) {
                 log.info("Loaded {d} pubkeys from bootstrapped kind 3 contact list", .{self.follow_pubkeys.items.len});
                 return;
@@ -169,7 +174,7 @@ pub const Spider = struct {
 
             const parsed = parseRelayUrl(relay_url) orelse continue;
 
-            var client = websocket.Client.init(self.allocator, .{
+            var client = websocket.Client.init(nostr.io.io(), self.allocator, .{
                 .host = parsed.host,
                 .port = parsed.port,
                 .tls = parsed.use_tls,
@@ -192,10 +197,9 @@ pub const Spider = struct {
 
             var events_received: u64 = 0;
             var got_kind3 = false;
-            const bootstrap_start = std.time.milliTimestamp();
-            while (std.time.milliTimestamp() - bootstrap_start < 10_000) {
-                const message = client.read() catch |err| {
-                    if (err == error.WouldBlock) continue;
+            const bootstrap_start = milliTimestamp();
+            while (milliTimestamp() - bootstrap_start < 10_000) {
+                const message = client.read() catch {
                     break;
                 };
                 if (message) |msg| {
@@ -276,16 +280,16 @@ pub const Spider = struct {
             if (!self.shouldRun()) break;
 
             const old_count = blk: {
-                self.follow_mutex.lock();
-                defer self.follow_mutex.unlock();
+                self.follow_mutex.lockUncancelable(nostr.io.io());
+                defer self.follow_mutex.unlock(nostr.io.io());
                 break :blk self.follow_pubkeys.items.len;
             };
 
             self.refreshFollowList();
 
             const new_count = blk: {
-                self.follow_mutex.lock();
-                defer self.follow_mutex.unlock();
+                self.follow_mutex.lockUncancelable(nostr.io.io());
+                defer self.follow_mutex.unlock(nostr.io.io());
                 break :blk self.follow_pubkeys.items.len;
             };
 
@@ -302,7 +306,7 @@ pub const Spider = struct {
 
         while (self.shouldRun()) {
             if (conn.blackout_until > 0) {
-                const now = std.time.milliTimestamp();
+                const now = milliTimestamp();
                 if (now < conn.blackout_until) {
                     const wait_ms: u64 = @intCast(conn.blackout_until - now);
                     log.info("{s}: In blackout for {d}ms more", .{ relay_url, wait_ms });
@@ -314,9 +318,9 @@ pub const Spider = struct {
             }
 
             log.info("{s}: Connecting...", .{relay_url});
-            const connect_start = std.time.milliTimestamp();
+            const connect_start = milliTimestamp();
             const success = self.connectAndSubscribe(conn, relay_url);
-            const connection_duration = std.time.milliTimestamp() - connect_start;
+            const connection_duration = milliTimestamp() - connect_start;
 
             if (!self.shouldRun()) break;
 
@@ -337,7 +341,7 @@ pub const Spider = struct {
             }
 
             if (conn.reconnect_delay_ms >= MAX_RECONNECT_DELAY_MS) {
-                conn.blackout_until = std.time.milliTimestamp() + @as(i64, @intCast(BLACKOUT_MS));
+                conn.blackout_until = milliTimestamp() + @as(i64, @intCast(BLACKOUT_MS));
                 conn.reconnect_delay_ms = RECONNECT_DELAY_MS;
                 log.warn("{s}: Entering 24h blackout", .{relay_url});
             }
@@ -348,7 +352,7 @@ pub const Spider = struct {
 
     fn connectAndSubscribe(self: *Spider, conn: *RelayConn, relay_url: []const u8) bool {
         if (conn.isRateLimited()) {
-            const wait_ms: u64 = @intCast(@max(0, conn.rate_limit_until - std.time.milliTimestamp()));
+            const wait_ms: u64 = @intCast(@max(0, conn.rate_limit_until - milliTimestamp()));
             log.info("{s}: Rate limited, waiting {d}ms", .{ relay_url, wait_ms });
             self.interruptibleSleep(wait_ms);
             if (!self.shouldRun()) return false;
@@ -359,7 +363,7 @@ pub const Spider = struct {
             return false;
         };
 
-        var client = websocket.Client.init(self.allocator, .{
+        var client = websocket.Client.init(nostr.io.io(), self.allocator, .{
             .host = parsed.host,
             .port = parsed.port,
             .tls = parsed.use_tls,
@@ -389,7 +393,7 @@ pub const Spider = struct {
 
         log.info("{s}: Connected{s}", .{ relay_url, if (parsed.use_tls) " (TLS)" else "" });
         conn.state = .connected;
-        const now = std.time.milliTimestamp();
+        const now = milliTimestamp();
 
         client.readTimeout(1000) catch {};
 
@@ -417,21 +421,21 @@ pub const Spider = struct {
 
         self.readLoop(&client, relay_url);
 
-        conn.last_disconnect = std.time.milliTimestamp();
+        conn.last_disconnect = milliTimestamp();
         conn.state = .disconnected;
         return true;
     }
 
     fn performCatchup(self: *Spider, client: *websocket.Client, conn: *RelayConn, relay_url: []const u8) bool {
         const since_ts = conn.last_disconnect - CATCHUP_WINDOW_MS;
-        const until_ts = std.time.milliTimestamp() + CATCHUP_WINDOW_MS;
+        const until_ts = milliTimestamp() + CATCHUP_WINDOW_MS;
         const since_unix = @divFloor(since_ts, 1000);
         const until_unix = @divFloor(until_ts, 1000);
 
         log.info("{s}: Performing catch-up from {d} to {d}", .{ relay_url, since_unix, until_unix });
 
-        self.follow_mutex.lock();
-        defer self.follow_mutex.unlock();
+        self.follow_mutex.lockUncancelable(nostr.io.io());
+        defer self.follow_mutex.unlock(nostr.io.io());
 
         if (self.follow_pubkeys.items.len == 0) return true;
 
@@ -447,11 +451,11 @@ pub const Spider = struct {
         };
 
         var catchup_events: u64 = 0;
-        const catchup_start = std.time.milliTimestamp();
+        const catchup_start = milliTimestamp();
         const catchup_timeout_ms: i64 = 30_000;
         var read_error = false;
 
-        while (std.time.milliTimestamp() - catchup_start < catchup_timeout_ms) {
+        while (milliTimestamp() - catchup_start < catchup_timeout_ms) {
             const message = client.read() catch {
                 read_error = true;
                 break;
@@ -494,12 +498,12 @@ pub const Spider = struct {
     }
 
     fn performNegentropySync(self: *Spider, client: *websocket.Client, relay_url: []const u8, conn: *RelayConn) bool {
-        self.follow_mutex.lock();
+        self.follow_mutex.lockUncancelable(nostr.io.io());
         const pubkeys = self.allocator.dupe([32]u8, self.follow_pubkeys.items) catch {
-            self.follow_mutex.unlock();
+            self.follow_mutex.unlock(nostr.io.io());
             return true;
         };
-        self.follow_mutex.unlock();
+        self.follow_mutex.unlock(nostr.io.io());
         defer self.allocator.free(pubkeys);
 
         if (pubkeys.len == 0) return true;
@@ -549,15 +553,14 @@ pub const Spider = struct {
         };
 
         var neg_open_buf: [131072]u8 = undefined;
-        var fbs_neg = std.io.fixedBufferStream(&neg_open_buf);
-        const neg_writer = fbs_neg.writer();
+        var neg_writer = std.Io.Writer.fixed(&neg_open_buf);
         neg_writer.print("[\"NEG-OPEN\",\"neg-sync\",{s},\"", .{filter_json}) catch {
             log.err("{s}: NEG-OPEN message too large", .{relay_url});
             return true;
         };
         for (init_msg) |b| neg_writer.print("{x:0>2}", .{b}) catch return true;
         neg_writer.writeAll("\"]") catch return true;
-        const neg_open = fbs_neg.getWritten();
+        const neg_open = neg_writer.buffered();
 
         client.writeText(@constCast(neg_open)) catch |err| {
             log.err("{s}: Failed to send NEG-OPEN: {}", .{ relay_url, err });
@@ -566,28 +569,27 @@ pub const Spider = struct {
 
         client.readTimeout(1000) catch {};
 
-        var have_ids: std.ArrayListUnmanaged([32]u8) = .{};
+        var have_ids: std.ArrayListUnmanaged([32]u8) = .empty;
         defer have_ids.deinit(self.allocator);
-        var need_ids: std.ArrayListUnmanaged([32]u8) = .{};
+        var need_ids: std.ArrayListUnmanaged([32]u8) = .empty;
         defer need_ids.deinit(self.allocator);
 
-        const sync_start = std.time.milliTimestamp();
+        const sync_start = milliTimestamp();
         const initial_timeout_ms: i64 = 5_000;
         const sync_timeout_ms: i64 = 60_000;
         var rounds: usize = 0;
         var got_response = false;
         var connection_alive = true;
 
-        while (std.time.milliTimestamp() - sync_start < sync_timeout_ms) {
+        while (milliTimestamp() - sync_start < sync_timeout_ms) {
             if (!self.shouldRun()) return false;
 
-            if (!got_response and std.time.milliTimestamp() - sync_start > initial_timeout_ms) {
+            if (!got_response and milliTimestamp() - sync_start > initial_timeout_ms) {
                 log.warn("{s}: No negentropy response, disabling for this relay", .{relay_url});
                 conn.negentropy_supported = false;
                 return true;
             }
-            const message = client.read() catch |err| {
-                if (err == error.WouldBlock) continue;
+            const message = client.read() catch {
                 connection_alive = false;
                 break;
             };
@@ -624,8 +626,7 @@ pub const Spider = struct {
                     }
 
                     var neg_msg_buf: [131072]u8 = undefined;
-                    var fbs_msg = std.io.fixedBufferStream(&neg_msg_buf);
-                    const msg_writer = fbs_msg.writer();
+                    var msg_writer = std.Io.Writer.fixed(&neg_msg_buf);
                     msg_writer.writeAll("[\"NEG-MSG\",\"neg-sync\",\"") catch {
                         result.deinit();
                         continue;
@@ -640,7 +641,7 @@ pub const Spider = struct {
                     };
                     result.deinit();
 
-                    client.writeText(@constCast(fbs_msg.getWritten())) catch {
+                    client.writeText(@constCast(msg_writer.buffered())) catch {
                         connection_alive = false;
                         break;
                     };
@@ -682,8 +683,7 @@ pub const Spider = struct {
             const batch = ids[i..end];
 
             var msg_buf: [65536]u8 = undefined;
-            var fbs = std.io.fixedBufferStream(&msg_buf);
-            const writer = fbs.writer();
+            var writer = std.Io.Writer.fixed(&msg_buf);
 
             const req_msg = build_req: {
                 writer.writeAll("[\"REQ\",\"fetch\",{\"ids\":[") catch break :build_req null;
@@ -694,7 +694,7 @@ pub const Spider = struct {
                     writer.writeAll("\"") catch break :build_req null;
                 }
                 writer.writeAll("]}]") catch break :build_req null;
-                break :build_req fbs.getWritten();
+                break :build_req writer.buffered();
             };
 
             if (req_msg) |msg| {
@@ -707,12 +707,11 @@ pub const Spider = struct {
                 continue;
             }
 
-            const fetch_start = std.time.milliTimestamp();
+            const fetch_start = milliTimestamp();
             var read_error = false;
-            while (std.time.milliTimestamp() - fetch_start < 30_000) {
+            while (milliTimestamp() - fetch_start < 30_000) {
                 if (!self.shouldRun()) return true;
-                const message = client.read() catch |err| {
-                    if (err == error.WouldBlock) continue;
+                const message = client.read() catch {
                     read_error = true;
                     break;
                 };
@@ -745,8 +744,8 @@ pub const Spider = struct {
     }
 
     fn sendSubscriptions(self: *Spider, client: *websocket.Client, relay_url: []const u8) !void {
-        self.follow_mutex.lock();
-        defer self.follow_mutex.unlock();
+        self.follow_mutex.lockUncancelable(nostr.io.io());
+        defer self.follow_mutex.unlock(nostr.io.io());
 
         if (self.follow_pubkeys.items.len == 0) {
             log.warn("{s}: No pubkeys to subscribe to", .{relay_url});
@@ -779,7 +778,7 @@ pub const Spider = struct {
             i = end;
 
             if (i < self.follow_pubkeys.items.len) {
-                std.Thread.sleep(BATCH_CREATION_DELAY_MS * std.time.ns_per_ms);
+                std.Io.sleep(nostr.io.io(), .{ .nanoseconds = @intCast(BATCH_CREATION_DELAY_MS * std.time.ns_per_ms) }, .awake) catch {};
             }
         }
 
@@ -793,7 +792,6 @@ pub const Spider = struct {
 
         while (self.shouldRun()) {
             const message = client.read() catch |err| {
-                if (err == error.WouldBlock) continue;
                 if (err == error.Closed or err == error.ConnectionResetByPeer) {
                     log.info("{s}: Connection closed", .{relay_url});
                 } else {
@@ -958,14 +956,14 @@ const RelayConn = struct {
     }
 
     fn applyRateLimit(self: *RelayConn) void {
-        const now = std.time.milliTimestamp();
+        const now = milliTimestamp();
         self.rate_limit_until = now + @as(i64, @intCast(self.rate_limit_backoff_ms));
         log.warn("{s}: Rate limited, backing off for {d}ms", .{ self.url, self.rate_limit_backoff_ms });
         self.rate_limit_backoff_ms = @min(self.rate_limit_backoff_ms * 2, MAX_RATE_LIMIT_BACKOFF_MS);
     }
 
     fn isRateLimited(self: *const RelayConn) bool {
-        return std.time.milliTimestamp() < self.rate_limit_until;
+        return milliTimestamp() < self.rate_limit_until;
     }
 
     fn clearRateLimit(self: *RelayConn) void {
@@ -1018,8 +1016,7 @@ fn parseRelayUrl(url: []const u8) ?ParsedUrl {
 }
 
 fn buildReqMessage(buf: []u8, batch_idx: usize, pubkeys: [][32]u8) ![]u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    const writer = fbs.writer();
+    var writer = std.Io.Writer.fixed(buf);
 
     try writer.print("[\"REQ\",\"spider-batch-{d}\",", .{batch_idx});
 
@@ -1037,12 +1034,11 @@ fn buildReqMessage(buf: []u8, batch_idx: usize, pubkeys: [][32]u8) ![]u8 {
     }
     try writer.writeAll("]}]");
 
-    return fbs.getWritten();
+    return writer.buffered();
 }
 
 fn buildCatchupReqMessage(buf: []u8, pubkeys: [][32]u8, since: i64, until: i64) ![]u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    const writer = fbs.writer();
+    var writer = std.Io.Writer.fixed(buf);
 
     try writer.writeAll("[\"REQ\",\"catchup\",");
     try writer.writeAll("{\"authors\":[");
@@ -1058,12 +1054,11 @@ fn buildCatchupReqMessage(buf: []u8, pubkeys: [][32]u8, since: i64, until: i64) 
     }
     try writer.print("],\"since\":{d},\"until\":{d}}}]", .{ since, until });
 
-    return fbs.getWritten();
+    return writer.buffered();
 }
 
 fn buildNegentropyFilter(buf: []u8, pubkeys: [][32]u8) ![]u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    const writer = fbs.writer();
+    var writer = std.Io.Writer.fixed(buf);
 
     try writer.writeAll("{\"authors\":[");
     for (pubkeys, 0..) |pk, i| {
@@ -1072,7 +1067,7 @@ fn buildNegentropyFilter(buf: []u8, pubkeys: [][32]u8) ![]u8 {
     }
     try writer.writeAll("]}");
 
-    return fbs.getWritten();
+    return writer.buffered();
 }
 
 fn extractNegPayload(data: []const u8) ?[]const u8 {

--- a/src/spider.zig
+++ b/src/spider.zig
@@ -414,10 +414,10 @@ pub const Spider = struct {
         conn.last_connect = now;
         conn.clearRateLimit();
 
-        const subscribed_count = blk: {
+        const subscribed_hash = blk: {
             self.follow_mutex.lockUncancelable(nostr.io.io());
             defer self.follow_mutex.unlock(nostr.io.io());
-            break :blk self.follow_pubkeys.items.len;
+            break :blk std.hash.Wyhash.hash(0, std.mem.sliceAsBytes(self.follow_pubkeys.items));
         };
 
         self.sendSubscriptions(&client, relay_url) catch |err| {
@@ -425,7 +425,7 @@ pub const Spider = struct {
             return false;
         };
 
-        self.readLoop(&client, relay_url, subscribed_count);
+        self.readLoop(&client, relay_url, subscribed_hash);
 
         conn.last_disconnect = milliTimestamp();
         conn.state = .disconnected;
@@ -791,22 +791,25 @@ pub const Spider = struct {
         log.info("{s}: Sent {d} subscription batches", .{ relay_url, batch_idx });
     }
 
-    fn readLoop(self: *Spider, client: *websocket.Client, relay_url: []const u8, subscribed_count: usize) void {
+    fn readLoop(self: *Spider, client: *websocket.Client, relay_url: []const u8, subscribed_hash: u64) void {
         var events_received: u64 = 0;
 
         client.readTimeout(1000) catch {};
 
         while (self.shouldRun()) {
-            // Re-subscribe when the follow list changes (e.g. the admin contact
-            // list was bootstrapped after connecting): exit so the relay loop
-            // reconnects, re-subscribes with the new pubkeys, and catches up.
-            const current_count = blk: {
+            // Re-subscribe when the follow list changes (added, removed, or
+            // replaced pubkeys): exit so the relay loop reconnects, re-subscribes
+            // with the current pubkeys, and catches up. The non-empty guard skips
+            // the transient empty state while refreshFollowList re-bootstraps.
+            const changed = blk: {
                 self.follow_mutex.lockUncancelable(nostr.io.io());
                 defer self.follow_mutex.unlock(nostr.io.io());
-                break :blk self.follow_pubkeys.items.len;
+                if (self.follow_pubkeys.items.len == 0) break :blk false;
+                const hash = std.hash.Wyhash.hash(0, std.mem.sliceAsBytes(self.follow_pubkeys.items));
+                break :blk hash != subscribed_hash;
             };
-            if (current_count > subscribed_count) {
-                log.info("{s}: Follow list grew ({d} -> {d}), reconnecting", .{ relay_url, subscribed_count, current_count });
+            if (changed) {
+                log.info("{s}: Follow list changed, reconnecting", .{relay_url});
                 break;
             }
 

--- a/src/spider.zig
+++ b/src/spider.zig
@@ -414,12 +414,18 @@ pub const Spider = struct {
         conn.last_connect = now;
         conn.clearRateLimit();
 
+        const subscribed_count = blk: {
+            self.follow_mutex.lockUncancelable(nostr.io.io());
+            defer self.follow_mutex.unlock(nostr.io.io());
+            break :blk self.follow_pubkeys.items.len;
+        };
+
         self.sendSubscriptions(&client, relay_url) catch |err| {
             log.err("{s}: Failed to send subscriptions: {}", .{ relay_url, err });
             return false;
         };
 
-        self.readLoop(&client, relay_url);
+        self.readLoop(&client, relay_url, subscribed_count);
 
         conn.last_disconnect = milliTimestamp();
         conn.state = .disconnected;
@@ -785,12 +791,25 @@ pub const Spider = struct {
         log.info("{s}: Sent {d} subscription batches", .{ relay_url, batch_idx });
     }
 
-    fn readLoop(self: *Spider, client: *websocket.Client, relay_url: []const u8) void {
+    fn readLoop(self: *Spider, client: *websocket.Client, relay_url: []const u8, subscribed_count: usize) void {
         var events_received: u64 = 0;
 
         client.readTimeout(1000) catch {};
 
         while (self.shouldRun()) {
+            // Re-subscribe when the follow list changes (e.g. the admin contact
+            // list was bootstrapped after connecting): exit so the relay loop
+            // reconnects, re-subscribes with the new pubkeys, and catches up.
+            const current_count = blk: {
+                self.follow_mutex.lockUncancelable(nostr.io.io());
+                defer self.follow_mutex.unlock(nostr.io.io());
+                break :blk self.follow_pubkeys.items.len;
+            };
+            if (current_count > subscribed_count) {
+                log.info("{s}: Follow list grew ({d} -> {d}), reconnecting", .{ relay_url, subscribed_count, current_count });
+                break;
+            }
+
             const message = client.read() catch |err| {
                 if (err == error.Closed or err == error.ConnectionResetByPeer) {
                     log.info("{s}: Connection closed", .{relay_url});

--- a/src/store.zig
+++ b/src/store.zig
@@ -265,7 +265,7 @@ pub const Store = struct {
         }
 
         try self.deleteEventInternal(&txn, &event);
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
         const now_bytes = std.mem.asBytes(&now);
         try txn.put(self.deleted, event_id, now_bytes);
         try txn.commit();
@@ -279,7 +279,7 @@ pub const Store = struct {
         var cursor = try txn.cursor(self.deleted);
         defer cursor.close();
 
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
         const cutoff = now - max_age_seconds;
         var deleted_count: u64 = 0;
 
@@ -313,7 +313,7 @@ pub const Store = struct {
         var cursor = try txn.cursor(self.idx_expiration);
         defer cursor.close();
 
-        const now: u64 = @intCast(std.time.timestamp());
+        const now: u64 = @intCast(nostr.io.timestamp());
         var expired_count: u64 = 0;
 
         var entry = try cursor.get(.first);

--- a/src/subscriptions.zig
+++ b/src/subscriptions.zig
@@ -5,14 +5,14 @@ const nostr = @import("nostr.zig");
 pub const Subscriptions = struct {
     allocator: std.mem.Allocator,
     connections: std.AutoHashMap(u64, *Connection),
-    rwlock: std.Thread.RwLock,
+    rwlock: std.Io.RwLock,
     kind_index: std.AutoHashMap(i32, std.ArrayListUnmanaged(u64)),
 
     pub fn init(allocator: std.mem.Allocator) Subscriptions {
         return .{
             .allocator = allocator,
             .connections = std.AutoHashMap(u64, *Connection).init(allocator),
-            .rwlock = .{},
+            .rwlock = .init,
             .kind_index = std.AutoHashMap(i32, std.ArrayListUnmanaged(u64)).init(allocator),
         };
     }
@@ -28,21 +28,24 @@ pub const Subscriptions = struct {
     }
 
     pub fn addConnection(self: *Subscriptions, conn: *Connection) !void {
-        self.rwlock.lock();
-        defer self.rwlock.unlock();
+        const io = nostr.io.io();
+        self.rwlock.lockUncancelable(io);
+        defer self.rwlock.unlock(io);
         try self.connections.put(conn.id, conn);
     }
 
     pub fn tryAddConnection(self: *Subscriptions, conn: *Connection, max_connections: usize) !void {
-        self.rwlock.lock();
-        defer self.rwlock.unlock();
+        const io = nostr.io.io();
+        self.rwlock.lockUncancelable(io);
+        defer self.rwlock.unlock(io);
         if (self.connections.count() >= max_connections) return error.TooManyConnections;
         try self.connections.put(conn.id, conn);
     }
 
     pub fn removeConnection(self: *Subscriptions, conn_id: u64) void {
-        self.rwlock.lock();
-        defer self.rwlock.unlock();
+        const io = nostr.io.io();
+        self.rwlock.lockUncancelable(io);
+        defer self.rwlock.unlock(io);
 
         var kind_iter = self.kind_index.valueIterator();
         while (kind_iter.next()) |list| {
@@ -58,22 +61,25 @@ pub const Subscriptions = struct {
     }
 
     pub fn getConnection(self: *Subscriptions, conn_id: u64) ?*Connection {
-        self.rwlock.lockShared();
-        defer self.rwlock.unlockShared();
+        const io = nostr.io.io();
+        self.rwlock.lockSharedUncancelable(io);
+        defer self.rwlock.unlockShared(io);
         return self.connections.get(conn_id);
     }
 
     pub fn withConnection(self: *Subscriptions, conn_id: u64, comptime func: fn (*Connection) void) void {
-        self.rwlock.lockShared();
-        defer self.rwlock.unlockShared();
+        const io = nostr.io.io();
+        self.rwlock.lockSharedUncancelable(io);
+        defer self.rwlock.unlockShared(io);
         if (self.connections.get(conn_id)) |conn| {
             func(conn);
         }
     }
 
     pub fn sendToConnection(self: *Subscriptions, conn_id: u64, data: []const u8) bool {
-        self.rwlock.lockShared();
-        defer self.rwlock.unlockShared();
+        const io = nostr.io.io();
+        self.rwlock.lockSharedUncancelable(io);
+        defer self.rwlock.unlockShared(io);
         if (self.connections.get(conn_id)) |conn| {
             return conn.send(data);
         }
@@ -81,8 +87,9 @@ pub const Subscriptions = struct {
     }
 
     pub fn closeIdleConnection(self: *Subscriptions, conn_id: u64, notice: []const u8) bool {
-        self.rwlock.lockShared();
-        defer self.rwlock.unlockShared();
+        const io = nostr.io.io();
+        self.rwlock.lockSharedUncancelable(io);
+        defer self.rwlock.unlockShared(io);
         if (self.connections.get(conn_id)) |conn| {
             conn.sendDirect(notice);
             conn.stopWriteQueue();
@@ -94,8 +101,9 @@ pub const Subscriptions = struct {
     }
 
     pub fn connectionCount(self: *Subscriptions) usize {
-        self.rwlock.lockShared();
-        defer self.rwlock.unlockShared();
+        const io = nostr.io.io();
+        self.rwlock.lockSharedUncancelable(io);
+        defer self.rwlock.unlockShared(io);
         return self.connections.count();
     }
 
@@ -106,8 +114,9 @@ pub const Subscriptions = struct {
         filters: []const nostr.Filter,
         max_subs: u32,
     ) !void {
-        self.rwlock.lock();
-        defer self.rwlock.unlock();
+        const io = nostr.io.io();
+        self.rwlock.lockUncancelable(io);
+        defer self.rwlock.unlock(io);
 
         try conn.addSubscription(sub_id, filters, max_subs);
 
@@ -116,7 +125,7 @@ pub const Subscriptions = struct {
                 for (kinds) |kind| {
                     var list = self.kind_index.getPtr(kind);
                     if (list == null) {
-                        try self.kind_index.put(kind, .{});
+                        try self.kind_index.put(kind, .empty);
                         list = self.kind_index.getPtr(kind);
                     }
 
@@ -133,16 +142,18 @@ pub const Subscriptions = struct {
     }
 
     pub fn unsubscribe(self: *Subscriptions, conn: *Connection, sub_id: []const u8) void {
-        self.rwlock.lock();
-        defer self.rwlock.unlock();
+        const io = nostr.io.io();
+        self.rwlock.lockUncancelable(io);
+        defer self.rwlock.unlock(io);
         conn.removeSubscription(sub_id);
     }
 
     pub fn getCandidates(self: *Subscriptions, event: *const nostr.Event) ![]*Connection {
-        self.rwlock.lockShared();
-        defer self.rwlock.unlockShared();
+        const io = nostr.io.io();
+        self.rwlock.lockSharedUncancelable(io);
+        defer self.rwlock.unlockShared(io);
 
-        var result = std.ArrayListUnmanaged(*Connection){};
+        var result: std.ArrayListUnmanaged(*Connection) = .empty;
         var seen = std.AutoHashMap(u64, void).init(self.allocator);
         defer seen.deinit();
 
@@ -185,8 +196,9 @@ pub const Subscriptions = struct {
         event: *const nostr.Event,
         msg_buf: *[65536]u8,
     ) void {
-        self.rwlock.lockShared();
-        defer self.rwlock.unlockShared();
+        const io = nostr.io.io();
+        self.rwlock.lockSharedUncancelable(io);
+        defer self.rwlock.unlockShared(io);
 
         var conn_iter = self.connections.valueIterator();
         while (conn_iter.next()) |conn| {
@@ -199,13 +211,14 @@ pub const Subscriptions = struct {
     }
 
     pub fn getIdleConnections(self: *Subscriptions, idle_seconds: u32) []u64 {
-        self.rwlock.lockShared();
-        defer self.rwlock.unlockShared();
+        const io = nostr.io.io();
+        self.rwlock.lockSharedUncancelable(io);
+        defer self.rwlock.unlockShared(io);
 
-        const now = std.time.timestamp();
+        const now = nostr.io.timestamp();
         const threshold = now - @as(i64, @intCast(idle_seconds));
 
-        var result = std.ArrayListUnmanaged(u64){};
+        var result: std.ArrayListUnmanaged(u64) = .empty;
         var conn_iter = self.connections.valueIterator();
         while (conn_iter.next()) |conn| {
             if (conn.*.last_activity < threshold) {

--- a/src/subscriptions.zig
+++ b/src/subscriptions.zig
@@ -154,6 +154,7 @@ pub const Subscriptions = struct {
         defer self.rwlock.unlockShared(io);
 
         var result: std.ArrayListUnmanaged(*Connection) = .empty;
+        errdefer result.deinit(self.allocator);
         var seen = std.AutoHashMap(u64, void).init(self.allocator);
         defer seen.deinit();
 
@@ -225,6 +226,9 @@ pub const Subscriptions = struct {
                 result.append(self.allocator, conn.*.id) catch continue;
             }
         }
-        return result.toOwnedSlice(self.allocator) catch &[_]u64{};
+        return result.toOwnedSlice(self.allocator) catch blk: {
+            result.deinit(self.allocator);
+            break :blk &[_]u64{};
+        };
     }
 };

--- a/src/tcp_server.zig
+++ b/src/tcp_server.zig
@@ -293,7 +293,14 @@ pub const TcpServer = struct {
             self.allocator.destroy(connection);
             return err;
         };
-        self.conn_limiter.addConnection(client_ip);
+        if (!self.conn_limiter.tryAcquireConnection(client_ip)) {
+            connection.stopWriteQueue();
+            connection.clearDirectWriter();
+            self.subs.removeConnection(conn_id);
+            connection.deinit();
+            self.allocator.destroy(connection);
+            return;
+        }
 
         defer {
             connection.stopWriteQueue();
@@ -566,6 +573,13 @@ pub const TcpServer = struct {
         };
 
         const formatted = std.fmt.bufPrint(buf, "{f}", .{addr}) catch return "unknown";
+        // IPv6 is formatted as "[addr]:port" — return the bracketed address so
+        // ACLs and per-IP limits see a plain IP (e.g. "::1", not "[::1]").
+        if (formatted.len > 0 and formatted[0] == '[') {
+            if (std.mem.indexOfScalar(u8, formatted, ']')) |end| {
+                return formatted[1..end];
+            }
+        }
         if (std.mem.lastIndexOf(u8, formatted, ":")) |colon| {
             return formatted[0..colon];
         }

--- a/src/tcp_server.zig
+++ b/src/tcp_server.zig
@@ -1,8 +1,20 @@
 const std = @import("std");
-const net = std.net;
+const net = std.Io.net;
 const posix = std.posix;
 const nostr = @import("nostr.zig");
 const ws = nostr.ws;
+
+fn streamWriteAll(stream: net.Stream, data: []const u8) !void {
+    const io = nostr.io.io();
+    var buf: [512]u8 = undefined;
+    var sw = stream.writer(io, &buf);
+    try sw.interface.writeAll(data);
+    try sw.interface.flush();
+}
+
+fn streamRead(stream: net.Stream, buf: []u8) !usize {
+    return std.posix.read(stream.socket.handle, buf);
+}
 
 const Config = @import("config.zig").Config;
 const MsgHandler = @import("handler.zig").Handler;
@@ -15,13 +27,14 @@ const Nip86Handler = @import("nip86.zig").Nip86Handler;
 
 const WsWriter = struct {
     stream: net.Stream,
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = .init,
     failed: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
 
     fn write(ctx: *anyopaque, data: []const u8) void {
         const self: *WsWriter = @ptrCast(@alignCast(ctx));
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         if (self.failed.load(.acquire)) return;
         self.writeWsFrame(data) catch {
             self.failed.store(true, .release);
@@ -55,27 +68,14 @@ const WsWriter = struct {
             header_len = 10;
         }
 
-        var iovecs = [_]std.posix.iovec_const{
-            .{ .base = &header, .len = header_len },
-            .{ .base = data.ptr, .len = data.len },
-        };
-        // SO_SNDTIMEO can make writev return a partial count without an error.
-        // Loop until every byte is written so a slow client can never leave a
-        // truncated frame behind (which would corrupt all later frames).
-        var i: usize = 0;
-        while (i < iovecs.len) {
-            const n = try self.stream.writev(iovecs[i..]);
-            if (n == 0) return error.ConnectionResetByPeer;
-            var rem = n;
-            while (i < iovecs.len and rem >= iovecs[i].len) {
-                rem -= iovecs[i].len;
-                i += 1;
-            }
-            if (i < iovecs.len and rem > 0) {
-                iovecs[i].base += rem;
-                iovecs[i].len -= rem;
-            }
-        }
+        // SO_SNDTIMEO can surface as a write error; writeVecAll loops until every
+        // byte is written so a slow client can never leave a truncated frame
+        // behind (which would corrupt all later frames).
+        const io = nostr.io.io();
+        var sw = self.stream.writer(io, &.{});
+        var vecs = [_][]const u8{ header[0..header_len], data };
+        try sw.interface.writeVecAll(&vecs);
+        try sw.interface.flush();
     }
 };
 
@@ -86,7 +86,7 @@ pub const TcpServer = struct {
     subs: *Subscriptions,
 
     next_id: u64 = 0,
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = .init,
 
     listener: ?net.Server = null,
     shutdown: *std.atomic.Value(bool),
@@ -121,7 +121,7 @@ pub const TcpServer = struct {
 
     pub fn deinit(self: *TcpServer) void {
         if (self.listener) |*l| {
-            l.deinit();
+            l.deinit(nostr.io.io());
             self.listener = null;
         }
         self.conn_limiter.deinit();
@@ -129,36 +129,37 @@ pub const TcpServer = struct {
     }
 
     pub fn run(self: *TcpServer) !void {
-        const address = try net.Address.parseIp(self.config.host, self.config.port);
-        self.listener = try address.listen(.{
+        const io = nostr.io.io();
+        const address = try net.IpAddress.parse(self.config.host, self.config.port);
+        self.listener = try address.listen(io, .{
             .reuse_address = true,
         });
 
-        // Wake accept() periodically (it would otherwise block indefinitely
-        // waiting for a connection) so the loop observes the shutdown flag set
-        // by SIGINT/SIGTERM and exits promptly for a graceful shutdown.
-        const accept_timeout = posix.timeval{ .sec = 1, .usec = 0 };
-        posix.setsockopt(self.listener.?.stream.handle, posix.SOL.SOCKET, posix.SO.RCVTIMEO, &std.mem.toBytes(accept_timeout)) catch {};
-
+        // Poll the listener with a 1s timeout so the loop observes the shutdown
+        // flag promptly. 0.16's Io.Threaded accept panics on EAGAIN, so the old
+        // SO_RCVTIMEO-on-accept trick is gone; poll first, accept only when ready.
         std.log.info("Server running on {s}:{d}", .{ self.config.host, self.config.port });
 
         const idle_thread = std.Thread.spawn(.{}, idleTimeoutThread, .{ self, self.shutdown }) catch null;
         defer if (idle_thread) |t| t.join();
 
         while (!self.shutdown.load(.acquire)) {
-            const conn = self.listener.?.accept() catch |err| {
+            var pfd = [_]posix.pollfd{.{ .fd = self.listener.?.socket.handle, .events = posix.POLL.IN, .revents = 0 }};
+            const ready = posix.poll(&pfd, 1000) catch 0;
+            if (ready == 0) continue;
+            const stream = self.listener.?.accept(io) catch |err| {
                 if (err == error.SocketNotListening) break;
                 continue;
             };
 
             if (self.subs.connectionCount() >= self.config.max_connections) {
-                conn.stream.close();
+                stream.close(io);
                 continue;
             }
 
-            const thread = std.Thread.spawn(.{}, handleConnection, .{ self, conn }) catch |err| {
+            const thread = std.Thread.spawn(.{}, handleConnection, .{ self, stream }) catch |err| {
                 std.log.warn("Failed to spawn connection thread: {}", .{err});
-                conn.stream.close();
+                stream.close(io);
                 continue;
             };
             thread.detach();
@@ -166,10 +167,10 @@ pub const TcpServer = struct {
 
         std.log.info("Shutting down server...", .{});
         if (self.listener) |*l| {
-            l.deinit();
+            l.deinit(io);
             self.listener = null;
         }
-        std.Thread.sleep(200 * std.time.ns_per_ms);
+        std.Io.sleep(io, .{ .nanoseconds = 200 * std.time.ns_per_ms }, .awake) catch {};
     }
 
     fn idleTimeoutThread(self: *TcpServer, shutdown: *std.atomic.Value(bool)) void {
@@ -177,7 +178,7 @@ pub const TcpServer = struct {
         var seconds_waited: u64 = 0;
 
         while (!shutdown.load(.acquire)) {
-            std.Thread.sleep(std.time.ns_per_s);
+            std.Io.sleep(nostr.io.io(), .{ .nanoseconds = std.time.ns_per_s }, .awake) catch {};
             if (shutdown.load(.acquire)) break;
             seconds_waited += 1;
             if (seconds_waited < check_interval_s) continue;
@@ -200,24 +201,24 @@ pub const TcpServer = struct {
 
     pub fn stop(self: *TcpServer) void {
         if (self.listener) |*l| {
-            l.deinit();
+            l.deinit(nostr.io.io());
             self.listener = null;
         }
     }
 
-    fn handleConnection(self: *TcpServer, conn: net.Server.Connection) void {
-        defer conn.stream.close();
+    fn handleConnection(self: *TcpServer, stream: net.Stream) void {
+        defer stream.close(nostr.io.io());
 
         // Check shutdown early to avoid accessing freed resources
         if (self.shutdown.load(.acquire)) return;
 
         var addr_buf: [64]u8 = undefined;
-        const socket_ip = extractIp(conn.address, &addr_buf);
+        const socket_ip = extractIp(stream.socket.handle, &addr_buf);
 
         if (self.shutdown.load(.acquire)) return;
 
         var buf: [8192]u8 = undefined;
-        const n = conn.stream.read(&buf) catch return;
+        const n = streamRead(stream, &buf) catch return;
         if (n == 0) return;
 
         const req_data = buf[0..n];
@@ -241,17 +242,17 @@ pub const TcpServer = struct {
         }
 
         if (isWebsocketUpgrade(req_data)) {
-            self.handleWebsocket(conn, client_ip, req_data) catch |err| {
+            self.handleWebsocket(stream, client_ip, req_data) catch |err| {
                 std.log.debug("Websocket error: {}", .{err});
             };
         } else {
-            self.handleHttp(conn, req_data) catch {};
+            self.handleHttp(stream, req_data) catch {};
         }
     }
 
-    fn handleWebsocket(self: *TcpServer, conn: net.Server.Connection, client_ip: []const u8, initial_data: []const u8) !void {
+    fn handleWebsocket(self: *TcpServer, stream: net.Stream, client_ip: []const u8, initial_data: []const u8) !void {
         const TCP_NODELAY = 1;
-        posix.setsockopt(conn.stream.handle, posix.IPPROTO.TCP, TCP_NODELAY, &std.mem.toBytes(@as(i32, 1))) catch {};
+        posix.setsockopt(stream.socket.handle, posix.IPPROTO.TCP, TCP_NODELAY, &std.mem.toBytes(@as(i32, 1))) catch {};
 
         // Bound how long a write to a slow/stalled client can block. REQ results
         // are streamed synchronously while an LMDB read txn is open, so without
@@ -259,7 +260,7 @@ pub const TcpServer = struct {
         // write errors and the direct writer is marked failed; the REQ streaming
         // loop observes that and breaks early, releasing the read txn promptly.
         const send_timeout = posix.timeval{ .sec = 10, .usec = 0 };
-        posix.setsockopt(conn.stream.handle, posix.SOL.SOCKET, posix.SO.SNDTIMEO, &std.mem.toBytes(send_timeout)) catch {};
+        posix.setsockopt(stream.socket.handle, posix.SOL.SOCKET, posix.SO.SNDTIMEO, &std.mem.toBytes(send_timeout)) catch {};
 
         const req, const consumed = try ws.handshake.Req.parse(initial_data);
         _ = consumed;
@@ -267,19 +268,20 @@ pub const TcpServer = struct {
         const accept = ws.handshake.secAccept(req.key);
         var response_buf: [256]u8 = undefined;
         const response = try std.fmt.bufPrint(&response_buf, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: {s}\r\n\r\n", .{&accept});
-        try conn.stream.writeAll(response);
+        try streamWriteAll(stream, response);
 
-        var ws_writer = WsWriter{ .stream = conn.stream };
+        var ws_writer = WsWriter{ .stream = stream };
 
-        self.mutex.lock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
         const conn_id = self.next_id;
         self.next_id += 1;
-        self.mutex.unlock();
+        self.mutex.unlock(io);
 
         const connection = try self.allocator.create(Connection);
         connection.init(self.allocator, conn_id);
         connection.setClientIp(client_ip);
-        connection.setSocketHandle(conn.stream.handle);
+        connection.setSocketHandle(stream.socket.handle);
         connection.setDirectWriter(WsWriter.write, @ptrCast(&ws_writer));
         connection.setDirectWriteFailedFlag(&ws_writer.failed);
         connection.startWriteQueue(WsWriter.write, @ptrCast(&ws_writer));
@@ -317,11 +319,11 @@ pub const TcpServer = struct {
                 var close_response: [16]u8 = undefined;
                 const close_frame = ws.Frame{ .fin = 1, .opcode = .close, .payload = &.{}, .mask = 0 };
                 const close_len = close_frame.encode(&close_response, 1002);
-                conn.stream.writeAll(close_response[0..close_len]) catch {};
+                streamWriteAll(stream, close_response[0..close_len]) catch {};
                 return;
             }
 
-            const bytes_read = conn.stream.read(frame_buf[read_pos..]) catch |err| {
+            const bytes_read = streamRead(stream, frame_buf[read_pos..]) catch |err| {
                 if (err == error.ConnectionResetByPeer or err == error.BrokenPipe) break;
                 return err;
             };
@@ -331,7 +333,7 @@ pub const TcpServer = struct {
             connection.touch();
 
             while (read_pos > 0) {
-                if (try self.checkOversizedFrame(connection, conn, frame_buf[0..read_pos])) return;
+                if (try self.checkOversizedFrame(connection, stream, frame_buf[0..read_pos])) return;
 
                 const frame, const frame_len = ws.Frame.parse(frame_buf[0..read_pos]) catch |err| {
                     if (err == error.SplitBuffer) break;
@@ -344,13 +346,13 @@ pub const TcpServer = struct {
                     var close_response: [16]u8 = undefined;
                     const close_frame = ws.Frame{ .fin = 1, .opcode = .close, .payload = &.{}, .mask = 0 };
                     const close_len = close_frame.encode(&close_response, 1000);
-                    conn.stream.writeAll(close_response[0..close_len]) catch {};
+                    streamWriteAll(stream, close_response[0..close_len]) catch {};
                     return;
                 } else if (frame.opcode == .ping) {
                     var pong_buf: [256]u8 = undefined;
                     const pong_frame = ws.Frame{ .fin = 1, .opcode = .pong, .payload = frame.payload, .mask = 0 };
                     const pong_len = pong_frame.encode(&pong_buf, 0);
-                    conn.stream.writeAll(pong_buf[0..pong_len]) catch {};
+                    streamWriteAll(stream, pong_buf[0..pong_len]) catch {};
                 } else if (frame.opcode == .text or frame.opcode == .binary) {
                     self.handler.handle(connection, frame.payload);
                 }
@@ -363,7 +365,7 @@ pub const TcpServer = struct {
         }
     }
 
-    fn checkOversizedFrame(self: *TcpServer, connection: *Connection, conn: net.Server.Connection, data: []const u8) !bool {
+    fn checkOversizedFrame(self: *TcpServer, connection: *Connection, stream: net.Stream, data: []const u8) !bool {
         if (data.len < 2) return false;
         const payload_len_byte: u8 = data[1] & 0b0111_1111;
         const payload_len: u64 = switch (payload_len_byte) {
@@ -386,29 +388,29 @@ pub const TcpServer = struct {
             var close_response: [16]u8 = undefined;
             const close_frame = ws.Frame{ .fin = 1, .opcode = .close, .payload = &.{}, .mask = 0 };
             const close_len = close_frame.encode(&close_response, 1009);
-            conn.stream.writeAll(close_response[0..close_len]) catch {};
+            streamWriteAll(stream, close_response[0..close_len]) catch {};
             return true;
         }
         return false;
     }
 
-    fn handleHttp(self: *TcpServer, conn: net.Server.Connection, req_data: []const u8) !void {
+    fn handleHttp(self: *TcpServer, stream: net.Stream, req_data: []const u8) !void {
         const is_options = std.mem.startsWith(u8, req_data, "OPTIONS ");
         const is_nip86_rpc = std.mem.indexOf(u8, req_data, "application/nostr+json+rpc") != null;
         const accepts_json = std.mem.indexOf(u8, req_data, "application/nostr+json") != null;
 
         if (is_nip86_rpc or is_options) {
-            try self.handleNip86(conn, req_data);
+            try self.handleNip86(stream, req_data);
         } else if (accepts_json) {
             var response_buf: [4096]u8 = undefined;
             var content_buf: [2048]u8 = undefined;
 
-            var content_stream = std.io.fixedBufferStream(&content_buf);
-            try nip11.write(self.config, self.nip86_handler, content_stream.writer());
-            const content = content_stream.getWritten();
+            var content_stream = std.Io.Writer.fixed(&content_buf);
+            try nip11.write(self.config, self.nip86_handler, &content_stream);
+            const content = content_stream.buffered();
 
             const response = try std.fmt.bufPrint(&response_buf, "HTTP/1.1 200 OK\r\nContent-Type: application/nostr+json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: {d}\r\n\r\n{s}", .{ content.len, content });
-            try conn.stream.writeAll(response);
+            try streamWriteAll(stream, response);
         } else {
             const html =
                 \\<!DOCTYPE html>
@@ -419,32 +421,32 @@ pub const TcpServer = struct {
                 \\</body></html>
             ;
             const response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: " ++ std.fmt.comptimePrint("{d}", .{html.len}) ++ "\r\n\r\n" ++ html;
-            try conn.stream.writeAll(response);
+            try streamWriteAll(stream, response);
         }
     }
 
-    fn handleNip86(self: *TcpServer, conn: net.Server.Connection, req_data: []const u8) !void {
+    fn handleNip86(self: *TcpServer, stream: net.Stream, req_data: []const u8) !void {
         if (std.mem.startsWith(u8, req_data, "OPTIONS ")) {
             const response = "HTTP/1.1 204 No Content\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Headers: Authorization, Content-Type\r\nAccess-Control-Allow-Methods: POST, OPTIONS\r\nAccess-Control-Max-Age: 86400\r\n\r\n";
-            try conn.stream.writeAll(response);
+            try streamWriteAll(stream, response);
             return;
         }
 
         if (!std.mem.startsWith(u8, req_data, "POST ")) {
             const response = "HTTP/1.1 405 Method Not Allowed\r\nAllow: POST, OPTIONS\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: 0\r\n\r\n";
-            try conn.stream.writeAll(response);
+            try streamWriteAll(stream, response);
             return;
         }
 
         if (self.config.admin_pubkeys.len == 0) {
             const response = "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: 39\r\n\r\n{\"error\":\"management API not enabled\"}";
-            try conn.stream.writeAll(response);
+            try streamWriteAll(stream, response);
             return;
         }
 
         const header_end = std.mem.indexOf(u8, req_data, "\r\n\r\n") orelse {
             const response = "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: 32\r\n\r\n{\"error\":\"missing request body\"}";
-            try conn.stream.writeAll(response);
+            try streamWriteAll(stream, response);
             return;
         };
         const body_offset = header_end + 4;
@@ -453,19 +455,19 @@ pub const TcpServer = struct {
         const content_length = blk: {
             const cl_str = extractHeader(req_data[0..header_end], "Content-Length: ") orelse {
                 const response = "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: 34\r\n\r\n{\"error\":\"missing Content-Length\"}";
-                try conn.stream.writeAll(response);
+                try streamWriteAll(stream, response);
                 return;
             };
             break :blk std.fmt.parseInt(usize, cl_str, 10) catch {
                 const response = "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: 34\r\n\r\n{\"error\":\"invalid Content-Length\"}";
-                try conn.stream.writeAll(response);
+                try streamWriteAll(stream, response);
                 return;
             };
         };
 
         if (content_length > max_body_size) {
             const response = "HTTP/1.1 413 Content Too Large\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: 34\r\n\r\n{\"error\":\"request body too large\"}";
-            try conn.stream.writeAll(response);
+            try streamWriteAll(stream, response);
             return;
         }
 
@@ -479,13 +481,13 @@ pub const TcpServer = struct {
         } else {
             body_buf = self.allocator.alloc(u8, content_length) catch {
                 const response = "HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nContent-Length: 25\r\n\r\n{\"error\":\"out of memory\"}";
-                try conn.stream.writeAll(response);
+                try streamWriteAll(stream, response);
                 return;
             };
             @memcpy(body_buf.?[0..initial_body.len], initial_body);
             var total_read = initial_body.len;
             while (total_read < content_length) {
-                const bytes = conn.stream.read(body_buf.?[total_read..content_length]) catch {
+                const bytes = streamRead(stream, body_buf.?[total_read..content_length]) catch {
                     return;
                 };
                 if (bytes == 0) return;
@@ -507,7 +509,7 @@ pub const TcpServer = struct {
         const reason = statusReason(result.status);
         var response_buf: [65536]u8 = undefined;
         const response = std.fmt.bufPrint(&response_buf, "HTTP/1.1 {d} {s}\r\nContent-Type: application/json\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Headers: Authorization, Content-Type\r\nAccess-Control-Allow-Methods: POST, OPTIONS\r\nContent-Length: {d}\r\n\r\n{s}", .{ result.status, reason, result.body.len, result.body }) catch return;
-        conn.stream.writeAll(response) catch {};
+        streamWriteAll(stream, response) catch {};
 
         if (result.owned) {
             self.allocator.free(result.body);
@@ -546,8 +548,24 @@ pub const TcpServer = struct {
         return std.ascii.indexOfIgnoreCase(data, "upgrade: websocket") != null;
     }
 
-    fn extractIp(address: net.Address, buf: []u8) []const u8 {
-        const formatted = std.fmt.bufPrint(buf, "{any}", .{address}) catch return "unknown";
+    fn extractIp(fd: posix.socket_t, buf: []u8) []const u8 {
+        var storage: posix.sockaddr.storage = undefined;
+        var len: posix.socklen_t = @sizeOf(posix.sockaddr.storage);
+        posix.getpeername(fd, @ptrCast(&storage), &len) catch return "unknown";
+
+        const addr: net.IpAddress = switch (storage.family) {
+            posix.AF.INET => blk: {
+                const sin: *const posix.sockaddr.in = @ptrCast(@alignCast(&storage));
+                break :blk .{ .ip4 = .{ .bytes = @bitCast(sin.addr), .port = std.mem.bigToNative(u16, sin.port) } };
+            },
+            posix.AF.INET6 => blk: {
+                const sin6: *const posix.sockaddr.in6 = @ptrCast(@alignCast(&storage));
+                break :blk .{ .ip6 = .{ .port = std.mem.bigToNative(u16, sin6.port), .bytes = sin6.addr } };
+            },
+            else => return "unknown",
+        };
+
+        const formatted = std.fmt.bufPrint(buf, "{f}", .{addr}) catch return "unknown";
         if (std.mem.lastIndexOf(u8, formatted, ":")) |colon| {
             return formatted[0..colon];
         }

--- a/src/write_queue.zig
+++ b/src/write_queue.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const nostr = @import("nostr.zig");
 
 pub const WriteFn = *const fn (ctx: *anyopaque, data: []const u8) void;
 
@@ -13,8 +14,8 @@ const QueuedMessage = struct {
 
 pub const WriteQueue = struct {
     messages: std.ArrayListUnmanaged(QueuedMessage),
-    mutex: std.Thread.Mutex,
-    not_empty: std.Thread.Condition,
+    mutex: std.Io.Mutex,
+    not_empty: std.Io.Condition,
     closed: std.atomic.Value(bool),
     stopped: std.atomic.Value(bool),
     write_thread: ?std.Thread,
@@ -26,9 +27,9 @@ pub const WriteQueue = struct {
 
     pub fn init(allocator: std.mem.Allocator) WriteQueue {
         return .{
-            .messages = .{},
-            .mutex = .{},
-            .not_empty = .{},
+            .messages = .empty,
+            .mutex = .init,
+            .not_empty = .init,
             .closed = std.atomic.Value(bool).init(false),
             .stopped = std.atomic.Value(bool).init(true),
             .write_thread = null,
@@ -67,21 +68,22 @@ pub const WriteQueue = struct {
 
         self.closed.store(true, .release);
 
-        self.mutex.lock();
-        self.not_empty.signal();
-        self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        self.not_empty.signal(io);
+        self.mutex.unlock(io);
 
         if (self.write_thread) |t| {
             t.join();
             self.write_thread = null;
         }
 
-        self.mutex.lock();
+        self.mutex.lockUncancelable(io);
         for (self.messages.items) |*msg| {
             msg.deinit();
         }
         self.messages.clearAndFree(self.allocator);
-        self.mutex.unlock();
+        self.mutex.unlock(io);
 
         self.write_fn = null;
         self.write_ctx = null;
@@ -98,8 +100,9 @@ pub const WriteQueue = struct {
             return false;
         };
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
 
         if (self.closed.load(.acquire)) {
             self.allocator.free(copy);
@@ -122,7 +125,7 @@ pub const WriteQueue = struct {
             return false;
         };
 
-        self.not_empty.signal();
+        self.not_empty.signal(io);
         return true;
     }
 
@@ -131,11 +134,12 @@ pub const WriteQueue = struct {
             var batch: []QueuedMessage = &.{};
 
             {
-                self.mutex.lock();
-                defer self.mutex.unlock();
+                const io = nostr.io.io();
+                self.mutex.lockUncancelable(io);
+                defer self.mutex.unlock(io);
 
                 while (self.messages.items.len == 0 and !self.closed.load(.acquire)) {
-                    self.not_empty.wait(&self.mutex);
+                    self.not_empty.waitUncancelable(io, &self.mutex);
                 }
 
                 if (self.closed.load(.acquire) and self.messages.items.len == 0) {
@@ -177,21 +181,23 @@ pub const WriteQueue = struct {
     }
 
     pub fn queueDepth(self: *WriteQueue) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         return self.messages.items.len;
     }
 };
 
 const TestContext = struct {
     received: std.ArrayListUnmanaged([]const u8),
-    mutex: std.Thread.Mutex,
+    mutex: std.Io.Mutex,
     allocator: std.mem.Allocator,
 
     fn write(ctx: *anyopaque, data: []const u8) void {
         const self: *TestContext = @ptrCast(@alignCast(ctx));
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
         const copy = self.allocator.dupe(u8, data) catch return;
         self.received.append(self.allocator, copy) catch {
             self.allocator.free(copy);
@@ -209,8 +215,8 @@ test "WriteQueue basic functionality" {
     var queue = WriteQueue.init(allocator);
 
     var ctx = TestContext{
-        .received = .{},
-        .mutex = .{},
+        .received = .empty,
+        .mutex = .init,
         .allocator = allocator,
     };
     defer ctx.deinit();
@@ -221,10 +227,11 @@ test "WriteQueue basic functionality" {
     try std.testing.expect(queue.enqueue("hello"));
     try std.testing.expect(queue.enqueue("world"));
 
-    std.Thread.sleep(50 * std.time.ns_per_ms);
+    const io = nostr.io.io();
+    std.Io.sleep(io, .{ .nanoseconds = 50 * std.time.ns_per_ms }, .awake) catch {};
 
-    ctx.mutex.lock();
-    defer ctx.mutex.unlock();
+    ctx.mutex.lockUncancelable(io);
+    defer ctx.mutex.unlock(io);
     try std.testing.expectEqual(@as(usize, 2), ctx.received.items.len);
     try std.testing.expectEqualStrings("hello", ctx.received.items[0]);
     try std.testing.expectEqualStrings("world", ctx.received.items[1]);
@@ -253,7 +260,7 @@ const BlockingWriter = struct {
         const self: *BlockingWriter = @ptrCast(@alignCast(ctx));
         self.started.store(true, .release);
         while (!self.release.load(.acquire)) {
-            std.Thread.sleep(1 * std.time.ns_per_ms);
+            std.Io.sleep(nostr.io.io(), .{ .nanoseconds = 1 * std.time.ns_per_ms }, .awake) catch {};
         }
     }
 };
@@ -274,7 +281,7 @@ test "WriteQueue respects max queue size" {
     try std.testing.expect(queue.enqueue("1"));
 
     while (!blocker.started.load(.acquire)) {
-        std.Thread.sleep(1 * std.time.ns_per_ms);
+        std.Io.sleep(nostr.io.io(), .{ .nanoseconds = 1 * std.time.ns_per_ms }, .awake) catch {};
     }
 
     try std.testing.expect(queue.enqueue("2"));

--- a/tests/test_lmdb.zig
+++ b/tests/test_lmdb.zig
@@ -25,7 +25,9 @@ pub fn main() !void {
     }
 
     // Create test directory
-    std.fs.cwd().makePath("./test_data") catch {};
+    var threaded = std.Io.Threaded.init(std.heap.page_allocator, .{});
+    defer threaded.deinit();
+    std.Io.Dir.cwd().createDirPath(threaded.io(), "./test_data") catch {};
 
     // Open environment
     rc = c.mdb_env_open(env, "./test_data/test.mdb", c.MDB_NOSUBDIR, 0o644);


### PR DESCRIPTION
Migrates wisp from Zig 0.15 to Zig 0.16 (stable), keeping the existing thread-per-connection architecture. This is the foundation for the epoll I/O rework (#64), done separately on top.

## Changes
- **Deps**: libnostr-z `v0.3.0` (Zig 0.16) and websocket.zig bumped to a 0.16-compatible commit.
- **Time/random/fs via `Io`**: 0.16 moved time, randomness, and the filesystem behind `std.Io`. Reuses libnostr-z's process-global blocking `Io` (`nostr.io.timestamp/nanoTimestamp/randomBytes/io`); filesystem ops thread `io` through `std.Io.Dir`/`std.Io.File`.
- **Writer overhaul**: `std.io.fixedBufferStream` → `std.Io.Writer.fixed`/`.buffered()`.
- **Sync/net**: `std.Thread.Mutex/Condition` → `std.Io.Mutex/Condition`; `std.net` → `std.Io.net` (listener + streams); args via `std.process.Args`.
- **Collections**: unmanaged `ArrayList`/`HashMap` `.{}` → `.empty`.
- **build.zig**: added a `test` step; CI workflows bumped to Zig 0.16.0.

## Bug fixes surfaced by 0.16
- **Accept loop**: 0.16's `Io.Threaded` accept panics on `EAGAIN`, so the old `SO_RCVTIMEO`-on-accept trick is gone. Replaced with `poll()` + accept-when-ready, preserving prompt shutdown.
- **SIGPIPE**: a client disconnecting mid-write previously terminated the process (latent in 0.15 too). Now ignored process-wide, surfacing as an `EPIPE` the write paths already handle. The relay now survives the 200-connection concurrency stress test.

## Testing
`zig build` and `zig build test` (Zig 0.16) pass. Validated live against the full integration suite: protocol round-trip (34/34), NIP-86 management (5/5), NIP-42 auth, NIP-70 protected, NIP-13 PoW, NIP-77 negentropy (3/3), and spider sync (negentropy client fetch). Behavior confirmed identical to v0.2.2 under concurrency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded to Zig 0.16.0 across CI/CD workflows and build configuration
  * Updated project dependencies including websocket and nostr libraries
  * Refactored internal I/O handling and synchronization mechanisms for improved reliability and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->