### PR TITLE
Add Prometheus metrics endpoint (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ For more options, see `wisp.toml.example`.
 * LMDB storage (no external database)
 * Spider mode for syncing events from external relays
 * Import/export to JSONL
+* Prometheus metrics at `GET /metrics`
+
+## Monitoring
+
+Operational metrics are exposed in Prometheus format at `GET /metrics` on the
+relay's port (connections, events stored/rejected/broadcast, REQ count, rate
+limiting). The endpoint honors the relay's IP allowlist/blocklist, so restrict
+it there or at your reverse proxy/firewall if you don't want it public.
 
 ## Import/Export
 

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -349,7 +349,7 @@ pub const Handler = struct {
 
         if (!result.stored) {
             const success = std.mem.startsWith(u8, result.message, "duplicate");
-            self.sendOk(conn, id, success, result.message);
+            self.replyOk(conn, id, success, result.message);
             return;
         }
 
@@ -555,7 +555,7 @@ pub const Handler = struct {
         const id = event.id();
 
         if (event.kind() != 22242) {
-            self.sendOk(conn, id, false, "invalid: AUTH event must be kind 22242");
+            self.replyOk(conn, id, false, "invalid: AUTH event must be kind 22242");
             return;
         }
 
@@ -563,7 +563,7 @@ pub const Handler = struct {
         const created = event.createdAt();
         const time_diff = if (now > created) now - created else created - now;
         if (time_diff > 600) {
-            self.sendOk(conn, id, false, "invalid: AUTH event timestamp too far from current time");
+            self.replyOk(conn, id, false, "invalid: AUTH event timestamp too far from current time");
             return;
         }
 
@@ -571,33 +571,33 @@ pub const Handler = struct {
 
         var expected_challenge: [64]u8 = undefined;
         _ = std.fmt.bufPrint(&expected_challenge, "{x}", .{conn.auth_challenge}) catch {
-            self.sendOk(conn, id, false, "error: internal error");
+            self.replyOk(conn, id, false, "error: internal error");
             return;
         };
 
         if (auth_tags.challenge == null or !std.mem.eql(u8, auth_tags.challenge.?, &expected_challenge)) {
-            self.sendOk(conn, id, false, "invalid: challenge mismatch");
+            self.replyOk(conn, id, false, "invalid: challenge mismatch");
             return;
         }
 
         if (self.config.relay_url.len > 0) {
             if (auth_tags.relay == null or !nostr.Auth.domainsMatch(self.config.relay_url, auth_tags.relay.?)) {
-                self.sendOk(conn, id, false, "invalid: relay URL mismatch");
+                self.replyOk(conn, id, false, "invalid: relay URL mismatch");
                 return;
             }
         }
 
         event.validate() catch |err| {
-            self.sendOk(conn, id, false, nostr.errorMessage(err));
+            self.replyOk(conn, id, false, nostr.errorMessage(err));
             return;
         };
 
         conn.addAuthenticatedPubkey(event.pubkey()) catch {
-            self.sendOk(conn, id, false, "error: failed to record authentication");
+            self.replyOk(conn, id, false, "error: failed to record authentication");
             return;
         };
 
-        self.sendOk(conn, id, true, "");
+        self.replyOk(conn, id, true, "");
     }
 
     fn handleNegOpen(self: *Handler, conn: *Connection, msg: *nostr.ClientMsg) void {
@@ -718,12 +718,19 @@ pub const Handler = struct {
         conn.write(msg) catch {};
     }
 
-    fn sendOk(self: *Handler, conn: *Connection, event_id: *const [32]u8, success: bool, message: []const u8) void {
-        if (success) metrics.eventStored() else metrics.eventRejected();
+    fn replyOk(self: *Handler, conn: *Connection, event_id: *const [32]u8, success: bool, message: []const u8) void {
         if (self.shutdown.load(.acquire)) return;
         var buf: [512]u8 = undefined;
         const msg = nostr.RelayMsg.ok(event_id, success, message, &buf) catch return;
         conn.write(msg) catch {};
+    }
+
+    /// OK responder for EVENT submissions: records the store/reject metric, then
+    /// replies. AUTH and duplicate acks use `replyOk` directly so they are not
+    /// miscounted as stored or rejected events.
+    fn sendOk(self: *Handler, conn: *Connection, event_id: *const [32]u8, success: bool, message: []const u8) void {
+        if (success) metrics.eventStored() else metrics.eventRejected();
+        self.replyOk(conn, event_id, success, message);
     }
 
     fn sendEose(self: *Handler, conn: *Connection, sub_id: []const u8) void {

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -9,6 +9,7 @@ const NegSession = connection.NegSession;
 const nostr = @import("nostr.zig");
 const rate_limiter = @import("rate_limiter.zig");
 const ManagementStore = @import("management_store.zig").ManagementStore;
+const metrics = @import("relay_metrics.zig");
 
 fn isKindOnlyQuery(f: *const nostr.Filter) bool {
     const kinds = f.kinds() orelse return false;
@@ -256,6 +257,7 @@ pub const Handler = struct {
         }
 
         if (!self.event_limiter.checkAndRecord(conn.getClientIp())) {
+            metrics.rateLimited();
             self.sendOk(conn, id, false, "rate-limited: too many events");
             return;
         }
@@ -400,6 +402,7 @@ pub const Handler = struct {
     }
 
     fn handleReq(self: *Handler, conn: *Connection, msg: *nostr.ClientMsg) void {
+        metrics.reqReceived();
         const sub_id_raw = msg.subscriptionId();
 
         if (sub_id_raw.len == 0 or sub_id_raw.len > 64) {
@@ -716,6 +719,7 @@ pub const Handler = struct {
     }
 
     fn sendOk(self: *Handler, conn: *Connection, event_id: *const [32]u8, success: bool, message: []const u8) void {
+        if (success) metrics.eventStored() else metrics.eventRejected();
         if (self.shutdown.load(.acquire)) return;
         var buf: [512]u8 = undefined;
         const msg = nostr.RelayMsg.ok(event_id, success, message, &buf) catch return;

--- a/src/main.zig
+++ b/src/main.zig
@@ -410,4 +410,5 @@ fn runExport(allocator: std.mem.Allocator, db_path: []const u8) !void {
 test {
     _ = @import("rate_limiter.zig");
     _ = @import("server.zig");
+    _ = @import("relay_metrics.zig");
 }

--- a/src/relay_metrics.zig
+++ b/src/relay_metrics.zig
@@ -51,3 +51,24 @@ pub fn write(w: anytype, active_connections: u64) !void {
     try metric(w, "wisp_req_total", "REQ subscription messages received", "counter", reqs_total.load(.monotonic));
     try metric(w, "wisp_rate_limited_total", "Connections/events rejected by rate or connection limits", "counter", rate_limited.load(.monotonic));
 }
+
+test write {
+    connectionOpened();
+    eventBroadcast(3);
+    eventBroadcast(0); // no-op: a zero-recipient broadcast must not move the counter
+
+    var buf: [4096]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try write(&w, 7);
+    const out = w.buffered();
+
+    // Each metric emits HELP, TYPE, and a value line.
+    try std.testing.expect(std.mem.indexOf(u8, out, "# HELP wisp_connections_total Total WebSocket connections accepted\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "# TYPE wisp_connections_total counter\n") != null);
+    // The active-connections gauge reflects the caller-supplied live count.
+    try std.testing.expect(std.mem.indexOf(u8, out, "# TYPE wisp_connections_active gauge\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "wisp_connections_active 7\n") != null);
+    // Counters carry the accumulated process-global totals.
+    try std.testing.expect(std.mem.indexOf(u8, out, "wisp_connections_total 1\n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "wisp_events_broadcast_total 3\n") != null);
+}

--- a/src/relay_metrics.zig
+++ b/src/relay_metrics.zig
@@ -1,0 +1,53 @@
+//! Lightweight, lock-free operational metrics exposed in Prometheus text format
+//! at GET /metrics. Counters are process-global atomics so any worker thread can
+//! update them without coordination; the active-connections gauge is read live
+//! from the subscription registry at scrape time.
+
+const std = @import("std");
+
+var connections_total = std.atomic.Value(u64).init(0);
+var events_stored = std.atomic.Value(u64).init(0);
+var events_rejected = std.atomic.Value(u64).init(0);
+var events_broadcast = std.atomic.Value(u64).init(0);
+var reqs_total = std.atomic.Value(u64).init(0);
+var rate_limited = std.atomic.Value(u64).init(0);
+
+pub fn connectionOpened() void {
+    _ = connections_total.fetchAdd(1, .monotonic);
+}
+
+pub fn eventStored() void {
+    _ = events_stored.fetchAdd(1, .monotonic);
+}
+
+pub fn eventRejected() void {
+    _ = events_rejected.fetchAdd(1, .monotonic);
+}
+
+pub fn eventBroadcast(count: u64) void {
+    if (count != 0) _ = events_broadcast.fetchAdd(count, .monotonic);
+}
+
+pub fn reqReceived() void {
+    _ = reqs_total.fetchAdd(1, .monotonic);
+}
+
+pub fn rateLimited() void {
+    _ = rate_limited.fetchAdd(1, .monotonic);
+}
+
+fn metric(w: anytype, name: []const u8, help: []const u8, kind: []const u8, value: u64) !void {
+    try w.print("# HELP {s} {s}\n# TYPE {s} {s}\n{s} {d}\n", .{ name, help, name, kind, name, value });
+}
+
+/// Write all metrics in Prometheus exposition format. `active_connections` is the
+/// live connection count, read from the registry by the caller at scrape time.
+pub fn write(w: anytype, active_connections: u64) !void {
+    try metric(w, "wisp_connections_total", "Total WebSocket connections accepted", "counter", connections_total.load(.monotonic));
+    try metric(w, "wisp_connections_active", "Currently open WebSocket connections", "gauge", active_connections);
+    try metric(w, "wisp_events_stored_total", "Events accepted and stored", "counter", events_stored.load(.monotonic));
+    try metric(w, "wisp_events_rejected_total", "Events rejected (validation, auth, limits, PoW, ...)", "counter", events_rejected.load(.monotonic));
+    try metric(w, "wisp_events_broadcast_total", "Events delivered to matching subscriptions", "counter", events_broadcast.load(.monotonic));
+    try metric(w, "wisp_req_total", "REQ subscription messages received", "counter", reqs_total.load(.monotonic));
+    try metric(w, "wisp_rate_limited_total", "Connections/events rejected by rate or connection limits", "counter", rate_limited.load(.monotonic));
+}

--- a/src/server.zig
+++ b/src/server.zig
@@ -122,7 +122,7 @@ pub const App = struct {
             res.status = 403;
             return;
         }
-        res.content_type = .TEXT;
+        res.header("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
         const w = res.writer();
         try metrics.write(w, app.subs.connectionCount());
     }

--- a/src/server.zig
+++ b/src/server.zig
@@ -10,6 +10,7 @@ const Connection = @import("connection.zig").Connection;
 const nip11 = @import("nip11.zig");
 const rate_limiter = @import("rate_limiter.zig");
 const Nip86Handler = @import("nip86.zig").Nip86Handler;
+const metrics = @import("relay_metrics.zig");
 
 const log = std.log.scoped(.server);
 
@@ -113,6 +114,19 @@ pub const App = struct {
         res.body = try res.arena.dupe(u8, result.body);
     }
 
+    /// GET /metrics — Prometheus operational metrics. Honors the same IP policy
+    /// as the relay, so an operator allowlist/blocklist also covers the scraper.
+    pub fn getMetrics(app: App, req: *httpz.Request, res: *httpz.Response) !void {
+        var ip_buf: [64]u8 = undefined;
+        if (app.ipDenied(app.clientIp(req, res, &ip_buf))) {
+            res.status = 403;
+            return;
+        }
+        res.content_type = .TEXT;
+        const w = res.writer();
+        try metrics.write(w, app.subs.connectionCount());
+    }
+
     /// OPTIONS / — CORS preflight.
     pub fn optionsRoot(_: App, _: *httpz.Request, res: *httpz.Response) !void {
         res.status = 204;
@@ -165,7 +179,10 @@ pub const WsConn = struct {
         const ip = ctx.ip();
 
         // Atomic per-IP connection limit.
-        if (!app.conn_limiter.tryAcquireConnection(ip)) return error.TooManyConnectionsPerIp;
+        if (!app.conn_limiter.tryAcquireConnection(ip)) {
+            metrics.rateLimited();
+            return error.TooManyConnectionsPerIp;
+        }
         errdefer app.conn_limiter.removeConnection(ip);
 
         const connection = try app.allocator.create(Connection);
@@ -189,6 +206,7 @@ pub const WsConn = struct {
 
         // Global connection limit + registry.
         try app.subs.tryAddConnection(connection, app.config.max_connections);
+        metrics.connectionOpened();
 
         var self = WsConn{
             .app = app,
@@ -343,6 +361,7 @@ pub const Server = struct {
 
         var router = try self.httpz_server.router(.{});
         router.get("/", App.getRoot, .{});
+        router.get("/metrics", App.getMetrics, .{});
         router.post("/", App.postRoot, .{});
         router.options("/", App.optionsRoot, .{});
 

--- a/src/subscriptions.zig
+++ b/src/subscriptions.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Connection = @import("connection.zig").Connection;
 const nostr = @import("nostr.zig");
+const metrics = @import("relay_metrics.zig");
 
 pub const Subscriptions = struct {
     allocator: std.mem.Allocator,
@@ -180,6 +181,7 @@ pub const Subscriptions = struct {
             }
         }
 
+        metrics.eventBroadcast(pending.items.len);
         for (pending.items) |item| {
             defer _ = item.conn.write_guard.fetchSub(1, .release);
             const msg = nostr.RelayMsg.event(item.sub_id, event, msg_buf) catch continue;

--- a/src/subscriptions.zig
+++ b/src/subscriptions.zig
@@ -181,13 +181,15 @@ pub const Subscriptions = struct {
             }
         }
 
-        metrics.eventBroadcast(pending.items.len);
+        var delivered: u64 = 0;
         for (pending.items) |item| {
             defer _ = item.conn.write_guard.fetchSub(1, .release);
             const msg = nostr.RelayMsg.event(item.sub_id, event, msg_buf) catch continue;
             item.conn.write(msg) catch {};
             _ = item.conn.events_sent.fetchAdd(1, .monotonic);
+            delivered += 1;
         }
+        metrics.eventBroadcast(delivered);
     }
 
     fn snapshotMatch(


### PR DESCRIPTION
Closes #50.

Exposes operational metrics in Prometheus exposition format at **`GET /metrics`** on the relay port. (Implemented as a Prometheus endpoint rather than the issue's older "via NIP-86" phrasing — it's the standard operators and tools like Prometheus/Grafana expect, and matches strfry/nostr-rs-relay.)

## Metrics
- `wisp_connections_total` (counter) — WebSocket connections accepted
- `wisp_connections_active` (gauge) — currently open connections (read live from the registry)
- `wisp_events_stored_total` / `wisp_events_rejected_total` (counters) — event outcomes (instrumented at the single `sendOk` choke point)
- `wisp_events_broadcast_total` (counter) — events delivered to matching subscriptions
- `wisp_req_total` (counter) — REQ messages received
- `wisp_rate_limited_total` (counter) — connections/events rejected by rate or connection limits

## Implementation
- New `src/relay_metrics.zig`: lock-free process-global atomic counters (safe across the epoll worker threads), Prometheus text output. No new dependency.
- Instrumented `handler.zig` (event outcomes, REQ, event rate limit), `subscriptions.zig` (broadcast fanout), `server.zig` (connection accept, per-IP limit).
- Route gated by the same IP policy as the relay (`ipDenied`), so an operator allowlist/blocklist also covers the scraper; restrict at the firewall/proxy otherwise.

## Testing
`zig build` + `zig build test` pass. Verified live: counters increment correctly under connect/publish/REQ/broadcast activity; endpoint returns HTTP 200 with valid Prometheus output.

The issue also listed query-latency; a latency histogram is a reasonable follow-up (kept out here to stay dependency-free and focused).