### PR TITLE
Fix event rate limiting for limits over 255

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -26,11 +26,7 @@ pub const Connection = struct {
     // writes internally, so both REQ streaming and broadcast use it directly.
     ws_conn: ?*websocket.Conn = null,
 
-    events_received: u64 = 0,
     events_sent: std.atomic.Value(u64) = .init(0),
-    event_timestamps: [256]i64 = undefined,
-    event_ts_head: u8 = 0,
-    event_ts_count: u8 = 0,
 
     client_ip: [64]u8 = undefined,
     client_ip_len: u8 = 0,
@@ -55,10 +51,7 @@ pub const Connection = struct {
         self.neg_sessions = std.StringHashMap(NegSession).init(self.arena.allocator());
         self.created_at = now;
         self.last_activity = .init(now);
-        self.events_received = 0;
         self.events_sent = .init(0);
-        self.event_ts_head = 0;
-        self.event_ts_count = 0;
         self.write_guard = .init(0);
         self.client_ip = undefined;
         self.client_ip_len = 0;
@@ -200,30 +193,6 @@ pub const Connection = struct {
         }
     }
 
-    pub fn checkEventRateLimit(self: *Connection, max_events_per_minute: u32) bool {
-        if (max_events_per_minute == 0) return true;
-        const now = nostr.io.timestamp();
-        const window_start = now - 60;
-        var count: u32 = 0;
-        var i: u8 = 0;
-        while (i < self.event_ts_count) : (i += 1) {
-            const idx = self.event_ts_head -% i -% 1;
-            if (self.event_timestamps[idx] >= window_start) {
-                count += 1;
-            }
-        }
-        return count < max_events_per_minute;
-    }
-
-    pub fn recordEvent(self: *Connection) void {
-        const now = nostr.io.timestamp();
-        self.event_timestamps[self.event_ts_head] = now;
-        self.event_ts_head +%= 1;
-        if (self.event_ts_count < 255) {
-            self.event_ts_count += 1;
-        }
-        self.events_received += 1;
-    }
 };
 
 pub const Subscription = struct {
@@ -243,35 +212,6 @@ fn eventJson(comptime kind: []const u8) []const u8 {
     return "[\"EVENT\",{\"id\":\"" ++ HID ++ "\",\"pubkey\":\"" ++ HPK ++
         "\",\"created_at\":1700000000,\"kind\":" ++ kind ++
         ",\"tags\":[],\"content\":\"hi\",\"sig\":\"" ++ HSIG ++ "\"}]";
-}
-
-test "checkEventRateLimit ring buffer" {
-    var conn: Connection = undefined;
-    conn.init(testing.allocator, 1);
-    defer conn.deinit();
-
-    // init() must zero the ring state; production allocates via create(),
-    // which does not apply field defaults.
-    try testing.expectEqual(@as(u8, 0), conn.event_ts_count);
-    try testing.expectEqual(@as(u8, 0), conn.event_ts_head);
-
-    // A zero limit disables rate limiting entirely.
-    try testing.expect(conn.checkEventRateLimit(0));
-    // An empty window is under any positive limit.
-    try testing.expect(conn.checkEventRateLimit(5));
-
-    var n: usize = 0;
-    while (n < 4) : (n += 1) conn.recordEvent();
-    try testing.expect(conn.checkEventRateLimit(5)); // 4 < 5
-    conn.recordEvent(); // 5th in the same window
-    try testing.expect(!conn.checkEventRateLimit(5)); // 5 is not < 5
-
-    // The 256-slot ring caps its in-window count at 255 no matter how many
-    // more arrive, so a limit above 255 can never be reached.
-    n = 0;
-    while (n < 300) : (n += 1) conn.recordEvent();
-    try testing.expect(!conn.checkEventRateLimit(255));
-    try testing.expect(conn.checkEventRateLimit(256));
 }
 
 test "addSubscription enforces max_subs" {

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -355,7 +355,6 @@ pub const Handler = struct {
         }
 
         self.sendOk(conn, id, true, "");
-        conn.recordEvent();
 
         self.broadcaster.broadcast(&event);
     }

--- a/src/rate_limiter.zig
+++ b/src/rate_limiter.zig
@@ -313,12 +313,14 @@ pub const EventRateLimiter = struct {
 
     pub fn checkAndRecord(self: *EventRateLimiter, ip: []const u8) bool {
         if (self.events_per_minute == 0) return true;
+        return self.checkAndRecordAt(ip, nostr.io.timestamp());
+    }
 
+    fn checkAndRecordAt(self: *EventRateLimiter, ip: []const u8, now: i64) bool {
         const io = nostr.io.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
 
-        const now = nostr.io.timestamp();
         const capacity: f64 = @floatFromInt(self.events_per_minute);
         const refill_per_sec: f64 = capacity / 60.0;
 
@@ -346,11 +348,14 @@ pub const EventRateLimiter = struct {
     }
 
     pub fn cleanup(self: *EventRateLimiter) void {
+        self.cleanupAt(nostr.io.timestamp());
+    }
+
+    fn cleanupAt(self: *EventRateLimiter, now: i64) void {
         const io = nostr.io.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
 
-        const now = nostr.io.timestamp();
         var to_remove: std.ArrayListUnmanaged([]const u8) = .empty;
         defer to_remove.deinit(self.allocator);
 
@@ -392,4 +397,63 @@ test "EventRateLimiter is disabled when the limit is zero" {
     while (i < 500) : (i += 1) {
         try std.testing.expect(limiter.checkAndRecord("9.9.9.9"));
     }
+}
+
+test "EventRateLimiter refills tokens over time" {
+    var limiter = EventRateLimiter.init(std.testing.allocator, 60); // 1 token/sec
+    defer limiter.deinit();
+
+    // Drain the full bucket within the same second.
+    var allowed: u32 = 0;
+    var i: u32 = 0;
+    while (i < 60) : (i += 1) {
+        if (limiter.checkAndRecordAt("1.2.3.4", 1000)) allowed += 1;
+    }
+    try std.testing.expectEqual(@as(u32, 60), allowed);
+    try std.testing.expect(!limiter.checkAndRecordAt("1.2.3.4", 1000)); // empty now
+
+    // After 10 seconds, ~10 tokens have refilled.
+    allowed = 0;
+    i = 0;
+    while (i < 20) : (i += 1) {
+        if (limiter.checkAndRecordAt("1.2.3.4", 1010)) allowed += 1;
+    }
+    try std.testing.expectEqual(@as(u32, 10), allowed);
+}
+
+test "EventRateLimiter tracks IPs independently" {
+    var limiter = EventRateLimiter.init(std.testing.allocator, 5);
+    defer limiter.deinit();
+
+    // Drain the first IP completely.
+    var i: u32 = 0;
+    while (i < 5) : (i += 1) {
+        try std.testing.expect(limiter.checkAndRecordAt("1.1.1.1", 1000));
+    }
+    try std.testing.expect(!limiter.checkAndRecordAt("1.1.1.1", 1000));
+
+    // A different IP is unaffected and gets its own full bucket.
+    i = 0;
+    while (i < 5) : (i += 1) {
+        try std.testing.expect(limiter.checkAndRecordAt("2.2.2.2", 1000));
+    }
+    try std.testing.expect(!limiter.checkAndRecordAt("2.2.2.2", 1000));
+}
+
+test "EventRateLimiter cleanup reclaims only idle buckets" {
+    var limiter = EventRateLimiter.init(std.testing.allocator, 10);
+    defer limiter.deinit();
+
+    try std.testing.expect(limiter.checkAndRecordAt("1.1.1.1", 1000));
+    try std.testing.expect(limiter.checkAndRecordAt("2.2.2.2", 1050));
+
+    // At t=1059, the first bucket is idle for 59s (<60), so nothing is reclaimed.
+    limiter.cleanupAt(1059);
+    try std.testing.expectEqual(@as(u32, 2), limiter.ip_buckets.count());
+
+    // At t=1060, the first bucket hits IDLE_SECONDS and is removed; the second
+    // (idle 10s) is retained.
+    limiter.cleanupAt(1060);
+    try std.testing.expectEqual(@as(u32, 1), limiter.ip_buckets.count());
+    try std.testing.expect(limiter.ip_buckets.contains("2.2.2.2"));
 }

--- a/src/rate_limiter.zig
+++ b/src/rate_limiter.zig
@@ -281,12 +281,17 @@ pub const EventRateLimiter = struct {
     ip_buckets: std.StringHashMap(EventBucket),
     events_per_minute: u32,
 
-    const WINDOW_SIZE: usize = 60;
+    // Idle buckets are reclaimed after this many seconds; a bucket idle for a
+    // full window has refilled to capacity, so dropping it is indistinguishable
+    // from a fresh IP.
+    const IDLE_SECONDS: i64 = 60;
 
+    // Token bucket per IP: capacity is events_per_minute, refilled at
+    // events_per_minute/60 tokens per second. O(1) state, so any configured
+    // limit is enforced (the previous 256-slot ring silently capped at 255).
     const EventBucket = struct {
-        timestamps: [256]i64,
-        head: u8,
-        count: u8,
+        tokens: f64,
+        last_refill: i64,
     };
 
     pub fn init(allocator: std.mem.Allocator, events_per_minute: u32) EventRateLimiter {
@@ -314,38 +319,26 @@ pub const EventRateLimiter = struct {
         defer self.mutex.unlock(io);
 
         const now = nostr.io.timestamp();
-        const window_start = now - WINDOW_SIZE;
+        const capacity: f64 = @floatFromInt(self.events_per_minute);
+        const refill_per_sec: f64 = capacity / 60.0;
 
         if (self.ip_buckets.getPtr(ip)) |bucket| {
-            var count: u32 = 0;
-            var i: u8 = 0;
-            while (i < bucket.count) : (i += 1) {
-                const idx = bucket.head -% i -% 1;
-                if (bucket.timestamps[idx] >= window_start) {
-                    count += 1;
-                }
+            const elapsed: f64 = @floatFromInt(@max(@as(i64, 0), now - bucket.last_refill));
+            bucket.tokens = @min(capacity, bucket.tokens + elapsed * refill_per_sec);
+            bucket.last_refill = now;
+            if (bucket.tokens >= 1.0) {
+                bucket.tokens -= 1.0;
+                return true;
             }
-
-            if (count >= self.events_per_minute) {
-                return false;
-            }
-
-            bucket.timestamps[bucket.head] = now;
-            bucket.head +%= 1;
-            if (bucket.count < 255) {
-                bucket.count += 1;
-            }
-            return true;
+            return false;
         }
 
+        // First event from this IP: start with a full bucket, then consume one.
         const ip_copy = self.allocator.dupe(u8, ip) catch return false;
-        var new_bucket = EventBucket{
-            .timestamps = undefined,
-            .head = 1,
-            .count = 1,
-        };
-        new_bucket.timestamps[0] = now;
-        self.ip_buckets.put(ip_copy, new_bucket) catch {
+        self.ip_buckets.put(ip_copy, .{
+            .tokens = capacity - 1.0,
+            .last_refill = now,
+        }) catch {
             self.allocator.free(ip_copy);
             return false;
         };
@@ -358,22 +351,12 @@ pub const EventRateLimiter = struct {
         defer self.mutex.unlock(io);
 
         const now = nostr.io.timestamp();
-        const window_start = now - WINDOW_SIZE;
         var to_remove: std.ArrayListUnmanaged([]const u8) = .empty;
         defer to_remove.deinit(self.allocator);
 
         var iter = self.ip_buckets.iterator();
         while (iter.next()) |entry| {
-            var has_recent = false;
-            var i: u8 = 0;
-            while (i < entry.value_ptr.count) : (i += 1) {
-                const idx = entry.value_ptr.head -% i -% 1;
-                if (entry.value_ptr.timestamps[idx] >= window_start) {
-                    has_recent = true;
-                    break;
-                }
-            }
-            if (!has_recent) {
+            if (now - entry.value_ptr.last_refill >= IDLE_SECONDS) {
                 to_remove.append(self.allocator, entry.key_ptr.*) catch continue;
             }
         }
@@ -384,3 +367,29 @@ pub const EventRateLimiter = struct {
         }
     }
 };
+
+test "EventRateLimiter enforces a limit above 255" {
+    var limiter = EventRateLimiter.init(std.testing.allocator, 300);
+    defer limiter.deinit();
+
+    // The bucket holds a full minute's capacity, so a burst within the same
+    // second allows up to 300 events and throttles the rest. The old 256-slot
+    // ring capped its count at 255, so a 300/min limit never tripped and all
+    // 400 would have passed.
+    var allowed: u32 = 0;
+    var i: u32 = 0;
+    while (i < 400) : (i += 1) {
+        if (limiter.checkAndRecord("1.2.3.4")) allowed += 1;
+    }
+    try std.testing.expect(allowed >= 300); // limit honored, not over-throttled
+    try std.testing.expect(allowed < 400); // and actually throttled
+}
+
+test "EventRateLimiter is disabled when the limit is zero" {
+    var limiter = EventRateLimiter.init(std.testing.allocator, 0);
+    defer limiter.deinit();
+    var i: u32 = 0;
+    while (i < 500) : (i += 1) {
+        try std.testing.expect(limiter.checkAndRecord("9.9.9.9"));
+    }
+}


### PR DESCRIPTION
Closes #78.

## The bug

`EventRateLimiter` tracked per-IP events in a 256-slot timestamp ring with a `u8` count capped at 255. Since the in-window count could never exceed 255, any `events_per_minute` of 256+ made the `count >= events_per_minute` check always false, silently disabling event rate limiting. The default (120) works, so this only bites operators who raise the limit.

(The issue pointed at `Connection.checkEventRateLimit`, but that path was dead code; the live limiter is `EventRateLimiter`, which had the identical bug. Both are addressed here.)

## The fix

Replaced the ring with a **token bucket** per IP (`tokens: f64`, `last_refill: i64`): capacity is `events_per_minute`, refilled at `events_per_minute/60` tokens per second. This is the standard approach (nostr-rs-relay uses GCRA via the `governor` crate; reverse proxies use leaky/token bucket):

- Enforces any configured limit correctly, no 255 ceiling.
- O(1) state per IP (~16 bytes vs ~2KB for the old ring).
- Smoother than the old fixed window.

## Dead-code removal

`Connection`'s per-connection rate limiter (`checkEventRateLimit`, `recordEvent`, the `[256]i64` timestamp ring, `events_received`) had no production callers, only `recordEvent` was invoked and its outputs were never read. Removed it, which also drops a **~2KB-per-connection** allocation (a small win toward #71/#64). The `checkEventRateLimit` unit test from #76 was testing this dead code and is removed accordingly.

## Tests

- New `EventRateLimiter` tests: a 300/min limit now throttles a 400-event burst (would have passed all 400 before), and a zero limit stays disabled. Verified stable across repeated runs; both token-bucket mutations are killed by the tests.
- `zig build test`: 20/20 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved event rate-limiting system for better scalability and resource efficiency. The system now supports higher event rate limits and optimizes memory usage during idle periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->