### PR TITLE
Reduce relay memory footprint

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -14,6 +14,10 @@ pub const Config = struct {
     pubkey: ?[]const u8,
     contact: ?[]const u8,
     max_connections: u32,
+    // Epoll worker threads. 0 means auto (scale with CPU, capped at 4). Lower it
+    // (e.g. 1) on a personal or memory-constrained relay: each worker carries its
+    // own buffer pools and thread subset, so fewer workers means a smaller footprint.
+    workers: u16,
     max_subscriptions: u32,
     max_filters: u32,
     max_message_size: u32,
@@ -65,6 +69,7 @@ pub const Config = struct {
             .pubkey = null,
             .contact = null,
             .max_connections = 1000,
+            .workers = 0,
             .max_subscriptions = 20,
             .max_filters = 10,
             .max_message_size = 65536,
@@ -163,6 +168,8 @@ pub const Config = struct {
         } else if (std.mem.eql(u8, section, "limits")) {
             if (std.mem.eql(u8, key, "max_connections")) {
                 self.max_connections = try std.fmt.parseInt(u32, value, 10);
+            } else if (std.mem.eql(u8, key, "workers")) {
+                self.workers = try std.fmt.parseInt(u16, value, 10);
             } else if (std.mem.eql(u8, key, "max_subscriptions")) {
                 self.max_subscriptions = try std.fmt.parseInt(u32, value, 10);
             } else if (std.mem.eql(u8, key, "max_filters")) {
@@ -272,6 +279,9 @@ pub const Config = struct {
         }
         if (getenv("WISP_MAX_CONNECTIONS_PER_IP")) |v| {
             self.max_connections_per_ip = std.fmt.parseInt(u32, v, 10) catch self.max_connections_per_ip;
+        }
+        if (getenv("WISP_WORKERS")) |v| {
+            self.workers = std.fmt.parseInt(u16, v, 10) catch self.workers;
         }
         if (getenv("WISP_EVENTS_PER_MINUTE")) |v| {
             self.events_per_minute = std.fmt.parseInt(u32, v, 10) catch self.events_per_minute;

--- a/src/server.zig
+++ b/src/server.zig
@@ -272,31 +272,44 @@ const PoolConfig = struct { workers: u16, pool: u16 };
 // the budget when it divides evenly (1/2/4 workers) and just under it otherwise
 // (30 on a 3-CPU host). The pool floor of 4 keeps each pool usable should the
 // worker cap ever exceed the budget; at the current cap of 4 it never binds.
-fn computePoolConfig(cpu_count: usize) PoolConfig {
+//
+// configured_workers comes from config.workers: 0 keeps the CPU-derived default,
+// any positive value overrides it (a personal or memory-constrained relay can set
+// 1 to shed the extra per-worker buffer pools and threads).
+fn computePoolConfig(cpu_count: usize, configured_workers: u16) PoolConfig {
     const total_handler_budget: usize = 32;
-    const worker_count = @max(@as(usize, 1), @min(cpu_count, 4));
+    const worker_count = if (configured_workers > 0)
+        @as(usize, configured_workers)
+    else
+        @max(@as(usize, 1), @min(cpu_count, 4));
     const pool_count = @max(@as(usize, 4), @divTrunc(total_handler_budget, worker_count));
     return .{ .workers = @intCast(worker_count), .pool = @intCast(pool_count) };
 }
 
 test computePoolConfig {
     // 1 worker gets the full budget.
-    try std.testing.expectEqual(PoolConfig{ .workers = 1, .pool = 32 }, computePoolConfig(1));
+    try std.testing.expectEqual(PoolConfig{ .workers = 1, .pool = 32 }, computePoolConfig(1, 0));
     // Budget splits evenly across 2 and 4 workers, holding the total at 32.
-    try std.testing.expectEqual(PoolConfig{ .workers = 2, .pool = 16 }, computePoolConfig(2));
-    try std.testing.expectEqual(PoolConfig{ .workers = 4, .pool = 8 }, computePoolConfig(4));
+    try std.testing.expectEqual(PoolConfig{ .workers = 2, .pool = 16 }, computePoolConfig(2, 0));
+    try std.testing.expectEqual(PoolConfig{ .workers = 4, .pool = 8 }, computePoolConfig(4, 0));
     // 3 workers: floor division leaves the total just under budget (3 * 10 = 30).
-    try std.testing.expectEqual(PoolConfig{ .workers = 3, .pool = 10 }, computePoolConfig(3));
+    try std.testing.expectEqual(PoolConfig{ .workers = 3, .pool = 10 }, computePoolConfig(3, 0));
     // Worker count is capped at 4, so more CPUs do not shrink the pool further.
-    try std.testing.expectEqual(PoolConfig{ .workers = 4, .pool = 8 }, computePoolConfig(8));
-    try std.testing.expectEqual(PoolConfig{ .workers = 4, .pool = 8 }, computePoolConfig(64));
+    try std.testing.expectEqual(PoolConfig{ .workers = 4, .pool = 8 }, computePoolConfig(8, 0));
+    try std.testing.expectEqual(PoolConfig{ .workers = 4, .pool = 8 }, computePoolConfig(64, 0));
     // Degenerate cpu_count of 0 (e.g. getCpuCount failure fallback) still yields one worker.
-    try std.testing.expectEqual(PoolConfig{ .workers = 1, .pool = 32 }, computePoolConfig(0));
+    try std.testing.expectEqual(PoolConfig{ .workers = 1, .pool = 32 }, computePoolConfig(0, 0));
 
-    // Total handler concurrency never exceeds the budget for any reachable cpu_count.
+    // A configured worker count overrides the CPU-derived default regardless of cpu_count.
+    try std.testing.expectEqual(PoolConfig{ .workers = 1, .pool = 32 }, computePoolConfig(16, 1));
+    try std.testing.expectEqual(PoolConfig{ .workers = 2, .pool = 16 }, computePoolConfig(16, 2));
+    // The budget still splits across configured workers, with the pool floor of 4.
+    try std.testing.expectEqual(PoolConfig{ .workers = 16, .pool = 4 }, computePoolConfig(16, 16));
+
+    // Total handler concurrency never exceeds the budget on the auto path.
     var cpu: usize = 0;
     while (cpu <= 128) : (cpu += 1) {
-        const cfg = computePoolConfig(cpu);
+        const cfg = computePoolConfig(cpu, 0);
         try std.testing.expect(@as(usize, cfg.workers) >= 1);
         try std.testing.expect(@as(usize, cfg.workers) * @as(usize, cfg.pool) <= 32);
     }
@@ -352,12 +365,22 @@ pub const Server = struct {
         // syscalls, while the handler thread pool is split from a fixed budget so
         // total handler concurrency does not multiply thread/buffer memory per worker.
         const cpu_count = std.Thread.getCpuCount() catch 1;
-        const pool_config = computePoolConfig(cpu_count);
+        const pool_config = computePoolConfig(cpu_count, config.workers);
 
+        // HTTP requests to a relay are small: a WS upgrade (GET /), a NIP-11 doc
+        // (GET /), or a NIP-86 management call (POST /). Events arrive over the
+        // WebSocket, bounded separately by max_message_size. So the httpz worker
+        // buffers are sized for small HTTP bodies, not for event payloads: the
+        // per-worker large-buffer pool (large_buffer_count * max_body_size) and
+        // the connection preallocation (min_conn) are the main idle-memory draws.
         self.httpz_server = try httpz.Server(App).init(io, allocator, .{
             .address = address,
-            .request = .{ .max_body_size = 131072 },
-            .workers = .{ .count = pool_config.workers },
+            .request = .{ .max_body_size = 65536 },
+            .workers = .{
+                .count = pool_config.workers,
+                .large_buffer_count = 4,
+                .min_conn = 8,
+            },
             .thread_pool = .{ .count = pool_config.pool },
             .websocket = .{ .max_message_size = config.max_message_size },
         }, app);

--- a/src/server.zig
+++ b/src/server.zig
@@ -275,11 +275,15 @@ const PoolConfig = struct { workers: u16, pool: u16 };
 //
 // configured_workers comes from config.workers: 0 keeps the CPU-derived default,
 // any positive value overrides it (a personal or memory-constrained relay can set
-// 1 to shed the extra per-worker buffer pools and threads).
+// 1 to shed the extra per-worker buffer pools and threads). The override is clamped
+// to max_workers so a typo (e.g. workers = 65535) cannot spawn tens of thousands of
+// threads and buffer pools, which would defeat the memory budget this feature exists
+// to protect.
 fn computePoolConfig(cpu_count: usize, configured_workers: u16) PoolConfig {
     const total_handler_budget: usize = 32;
+    const max_workers: usize = 64;
     const worker_count = if (configured_workers > 0)
-        @as(usize, configured_workers)
+        @min(@as(usize, configured_workers), max_workers)
     else
         @max(@as(usize, 1), @min(cpu_count, 4));
     const pool_count = @max(@as(usize, 4), @divTrunc(total_handler_budget, worker_count));
@@ -305,6 +309,9 @@ test computePoolConfig {
     try std.testing.expectEqual(PoolConfig{ .workers = 2, .pool = 16 }, computePoolConfig(16, 2));
     // The budget still splits across configured workers, with the pool floor of 4.
     try std.testing.expectEqual(PoolConfig{ .workers = 16, .pool = 4 }, computePoolConfig(16, 16));
+    // The override is clamped at 64, so a runaway value cannot spawn unbounded workers.
+    try std.testing.expectEqual(PoolConfig{ .workers = 64, .pool = 4 }, computePoolConfig(4, 64));
+    try std.testing.expectEqual(PoolConfig{ .workers = 64, .pool = 4 }, computePoolConfig(4, 65535));
 
     // Total handler concurrency never exceeds the budget on the auto path.
     var cpu: usize = 0;

--- a/wisp.toml.example
+++ b/wisp.toml.example
@@ -23,6 +23,9 @@ path = "./data"
 
 [limits]
 max_connections = 1000
+# Epoll worker threads. 0 = auto (scales with CPU, capped at 4). Set to 1 on a
+# personal or memory-constrained relay to shed per-worker buffers and threads.
+workers = 0
 max_subscriptions = 20
 max_filters = 10
 max_message_size = 65536


### PR DESCRIPTION
Addresses #71. Two safe, validated reductions plus a deployment-aware knob; no throughput regression.

## Changes

**Buffer right-sizing (`server.zig`).** HTTP requests to a relay are small (WS upgrade, NIP-11 doc, NIP-86 call); events arrive over the WebSocket, bounded by `max_message_size`. The httpz worker buffers were sized for event-sized bodies:
- `request.max_body_size` 131072 → 65536 (this drives the per-worker large-buffer size)
- `workers.large_buffer_count` 16 → 4
- `workers.min_conn` 64 → 8

**`WISP_WORKERS` knob (`config.zig` + `server.zig`).** Epoll worker count is now configurable (`workers` in `[limits]`, or `WISP_WORKERS`). Default is unchanged (auto: `min(cpu, 4)`); a personal or memory-constrained relay can set `1` to shed per-worker buffer pools and threads. `computePoolConfig` still splits the fixed handler-pool budget across workers.

## Measurements (16-core box, ReleaseFast, apples-to-apples)

| Config | idle RssAnon | peak-write | ev/s |
|---|---|---|---|
| main (before) | 12.9 MB | 13.6 MB | 22,744 |
| this PR, default | 11.3 MB | 11.7 MB | 23,653 |
| this PR, `workers=1` | 10.2 MB | 11.4 MB | 21,455 |

- Idle drops ~12% by default (free), ~21% in low-memory mode.
- Throughput is neutral at the default; `workers=1` trades ~9% for the smaller footprint, still far ahead of the field (strfry ~2.7k, nostr-rs-relay ~5k ev/s).
- Connection churn still plateaus (11.27 → 11.49 MB over 1500 open/close cycles), so #64's no-leak property holds.

## Not addressed here

The full multi-phase benchmark peaks at ~32 MB during the **concurrent query/store** phase (transient working set; the query path uses a lazy LMDB iterator, not full-result materialization). That is a separate, deeper target and is filed as a follow-up. This PR is the safe, no-downside set plus the operator lever the issue asked for.

23/23 unit tests pass (includes new `computePoolConfig` override cases).