### PR TITLE
Security hardening: query rate limiting, IP matching, proxy headers, negentropy auth

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,7 +45,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/wisp-data
-          WISP_STORAGE_PATH=/tmp/wisp-data/wisp.lmdb ./zig-out/bin/wisp &
+          WISP_EVENTS_PER_MINUTE=100000 WISP_QUERIES_PER_MINUTE=100000 \
+            WISP_STORAGE_PATH=/tmp/wisp-data/wisp.lmdb ./zig-out/bin/wisp &
           WISP_PID=$!
           trap 'kill ${WISP_PID} 2>/dev/null || true' EXIT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
             kill -9 "$1" 2>/dev/null || true
           }
           nohup env WISP_HOST=127.0.0.1 WISP_PORT=7782 WISP_EVENTS_PER_MINUTE=100000 \
+            WISP_QUERIES_PER_MINUTE=100000 \
             WISP_STORAGE_PATH="$RUNNER_TEMP/wisp-cc" \
             ./zig-out/bin/wisp relay > relay-cc.log 2>&1 &
           pid=$!
@@ -170,6 +171,7 @@ jobs:
           }
           admin=79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798
           nohup env WISP_HOST=127.0.0.1 WISP_PORT=7783 WISP_EVENTS_PER_MINUTE=100000 \
+            WISP_QUERIES_PER_MINUTE=100000 \
             WISP_STORAGE_PATH="$RUNNER_TEMP/wisp-src" \
             ./zig-out/bin/wisp relay > relay-src.log 2>&1 &
           src=$!

--- a/src/config.zig
+++ b/src/config.zig
@@ -31,6 +31,8 @@ pub const Config = struct {
     storage_map_size_mb: u32,
     idle_seconds: u32,
     events_per_minute: u32,
+    // Per-IP limit on expensive query messages (REQ/COUNT/NEG_OPEN). 0 disables.
+    queries_per_minute: u32,
     deleted_retention_days: u32,
 
     auth_required: bool,
@@ -83,6 +85,7 @@ pub const Config = struct {
             .storage_map_size_mb = 10240,
             .idle_seconds = 300,
             .events_per_minute = 120,
+            .queries_per_minute = 300,
             .deleted_retention_days = 90,
             .auth_required = false,
             .auth_to_write = false,
@@ -204,6 +207,8 @@ pub const Config = struct {
         } else if (std.mem.eql(u8, section, "rate_limits")) {
             if (std.mem.eql(u8, key, "events_per_minute")) {
                 self.events_per_minute = try std.fmt.parseInt(u32, value, 10);
+            } else if (std.mem.eql(u8, key, "queries_per_minute")) {
+                self.queries_per_minute = try std.fmt.parseInt(u32, value, 10);
             }
         } else if (std.mem.eql(u8, section, "auth")) {
             if (std.mem.eql(u8, key, "required")) {
@@ -285,6 +290,9 @@ pub const Config = struct {
         }
         if (getenv("WISP_EVENTS_PER_MINUTE")) |v| {
             self.events_per_minute = std.fmt.parseInt(u32, v, 10) catch self.events_per_minute;
+        }
+        if (getenv("WISP_QUERIES_PER_MINUTE")) |v| {
+            self.queries_per_minute = std.fmt.parseInt(u32, v, 10) catch self.queries_per_minute;
         }
         if (getenv("WISP_IDLE_SECONDS")) |v| {
             self.idle_seconds = std.fmt.parseInt(u32, v, 10) catch self.idle_seconds;

--- a/src/config.zig
+++ b/src/config.zig
@@ -40,6 +40,9 @@ pub const Config = struct {
     relay_url: []const u8,
 
     trust_proxy: bool,
+    // Comma-separated IPs/prefixes of reverse proxies whose forwarded headers are
+    // honored. Empty with trust_proxy=true honors headers from any peer.
+    trusted_proxies: []const u8,
     max_connections_per_ip: u32,
     ip_whitelist: []const u8,
     ip_blacklist: []const u8,
@@ -54,6 +57,10 @@ pub const Config = struct {
     // Negentropy (NIP-77) configuration
     negentropy_enabled: bool,
     negentropy_max_sync_events: u32,
+    // Concurrent negentropy sessions per connection. Each buffers up to
+    // negentropy_max_sync_events IDs, so this is kept small independent of
+    // max_subscriptions.
+    max_neg_sessions: u32,
 
     min_pow_difficulty: u8,
 
@@ -91,6 +98,7 @@ pub const Config = struct {
             .auth_to_write = false,
             .relay_url = "",
             .trust_proxy = false,
+            .trusted_proxies = "",
             .max_connections_per_ip = 10,
             .ip_whitelist = "",
             .ip_blacklist = "",
@@ -101,6 +109,7 @@ pub const Config = struct {
             .spider_sync_interval = 300,
             .negentropy_enabled = true,
             .negentropy_max_sync_events = 1000000,
+            .max_neg_sessions = 4,
             .min_pow_difficulty = 0,
             .admin_pubkeys = "",
             ._allocated = undefined,
@@ -221,6 +230,8 @@ pub const Config = struct {
         } else if (std.mem.eql(u8, section, "security")) {
             if (std.mem.eql(u8, key, "trust_proxy")) {
                 self.trust_proxy = std.mem.eql(u8, value, "true") or std.mem.eql(u8, value, "1");
+            } else if (std.mem.eql(u8, key, "trusted_proxies")) {
+                self.trusted_proxies = try self.allocString(value);
             } else if (std.mem.eql(u8, key, "max_connections_per_ip")) {
                 self.max_connections_per_ip = try std.fmt.parseInt(u32, value, 10);
             } else if (std.mem.eql(u8, key, "ip_whitelist")) {
@@ -245,6 +256,8 @@ pub const Config = struct {
                 self.negentropy_enabled = std.mem.eql(u8, value, "true") or std.mem.eql(u8, value, "1");
             } else if (std.mem.eql(u8, key, "max_sync_events")) {
                 self.negentropy_max_sync_events = try std.fmt.parseInt(u32, value, 10);
+            } else if (std.mem.eql(u8, key, "max_sessions")) {
+                self.max_neg_sessions = try std.fmt.parseInt(u32, value, 10);
             }
         } else if (std.mem.eql(u8, section, "management")) {
             if (std.mem.eql(u8, key, "admin_pubkeys")) {
@@ -282,6 +295,7 @@ pub const Config = struct {
         if (getenv("WISP_TRUST_PROXY")) |v| {
             self.trust_proxy = std.mem.eql(u8, v, "true") or std.mem.eql(u8, v, "1");
         }
+        if (getenv("WISP_TRUSTED_PROXIES")) |v| self.trusted_proxies = v;
         if (getenv("WISP_MAX_CONNECTIONS_PER_IP")) |v| {
             self.max_connections_per_ip = std.fmt.parseInt(u32, v, 10) catch self.max_connections_per_ip;
         }
@@ -313,6 +327,9 @@ pub const Config = struct {
         }
         if (getenv("WISP_NEGENTROPY_MAX_SYNC_EVENTS")) |v| {
             self.negentropy_max_sync_events = std.fmt.parseInt(u32, v, 10) catch self.negentropy_max_sync_events;
+        }
+        if (getenv("WISP_NEGENTROPY_MAX_SESSIONS")) |v| {
+            self.max_neg_sessions = std.fmt.parseInt(u32, v, 10) catch self.max_neg_sessions;
         }
         if (getenv("WISP_MIN_POW_DIFFICULTY")) |v| {
             self.min_pow_difficulty = std.fmt.parseInt(u8, v, 10) catch self.min_pow_difficulty;

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -108,9 +108,10 @@ pub const Connection = struct {
     pub fn deinit(self: *Connection) void {
         if (self.deinitialized) return;
         self.deinitialized = true;
-        var neg_iter = self.neg_sessions.valueIterator();
-        while (neg_iter.next()) |session| {
-            session.deinit();
+        var neg_iter = self.neg_sessions.iterator();
+        while (neg_iter.next()) |entry| {
+            entry.value_ptr.deinit();
+            self.backing_allocator.free(entry.key_ptr.*);
         }
         self.arena.deinit();
     }
@@ -148,12 +149,16 @@ pub const Connection = struct {
     }
 
     pub fn addNegSession(self: *Connection, sub_id: []const u8) !*NegSession {
-        const alloc = self.allocator();
+        // Reuse the existing key/slot on re-open so the previously duped key is not
+        // leaked. Keys are owned by backing_allocator (not the arena) so close can
+        // free them; the arena only frees on connection teardown.
         if (self.neg_sessions.getPtr(sub_id)) |existing| {
             existing.deinit();
-            _ = self.neg_sessions.remove(sub_id);
+            existing.* = NegSession.init(self.backing_allocator);
+            return existing;
         }
-        const sub_id_copy = try alloc.dupe(u8, sub_id);
+        const sub_id_copy = try self.backing_allocator.dupe(u8, sub_id);
+        errdefer self.backing_allocator.free(sub_id_copy);
         try self.neg_sessions.put(sub_id_copy, NegSession.init(self.backing_allocator));
         return self.neg_sessions.getPtr(sub_id_copy).?;
     }
@@ -163,10 +168,11 @@ pub const Connection = struct {
     }
 
     pub fn removeNegSession(self: *Connection, sub_id: []const u8) void {
-        if (self.neg_sessions.getPtr(sub_id)) |session| {
+        if (self.neg_sessions.fetchRemove(sub_id)) |kv| {
+            var session = kv.value;
             session.deinit();
+            self.backing_allocator.free(kv.key);
         }
-        _ = self.neg_sessions.remove(sub_id);
     }
 
     pub fn matchesEvent(self: *Connection, event: *const nostr.Event) ?[]const u8 {

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -152,6 +152,7 @@ pub const Handler = struct {
     subs: *Subscriptions,
     broadcaster: *Broadcaster,
     event_limiter: *rate_limiter.EventRateLimiter,
+    query_limiter: *rate_limiter.EventRateLimiter,
     shutdown: *std.atomic.Value(bool),
     mgmt_store: *ManagementStore,
 
@@ -162,6 +163,7 @@ pub const Handler = struct {
         subs: *Subscriptions,
         broadcaster: *Broadcaster,
         event_limiter: *rate_limiter.EventRateLimiter,
+        query_limiter: *rate_limiter.EventRateLimiter,
         shutdown: *std.atomic.Value(bool),
         mgmt_store: *ManagementStore,
     ) Handler {
@@ -172,6 +174,7 @@ pub const Handler = struct {
             .subs = subs,
             .broadcaster = broadcaster,
             .event_limiter = event_limiter,
+            .query_limiter = query_limiter,
             .shutdown = shutdown,
             .mgmt_store = mgmt_store,
         };
@@ -415,6 +418,12 @@ pub const Handler = struct {
         @memcpy(sub_id_buf[0..sub_id_raw.len], sub_id_raw);
         const sub_id = sub_id_buf[0..sub_id_raw.len];
 
+        if (!self.query_limiter.checkAndRecord(conn.getClientIp())) {
+            metrics.rateLimited();
+            self.sendClosed(conn, sub_id, "rate-limited: too many queries");
+            return;
+        }
+
         if (self.config.auth_required) {
             if (!conn.isAuthenticated()) {
                 self.sendClosed(conn, sub_id, "auth-required: authentication required to subscribe");
@@ -500,6 +509,12 @@ pub const Handler = struct {
 
         if (sub_id.len == 0 or sub_id.len > 64) {
             self.sendClosed(conn, sub_id, "error: invalid subscription ID");
+            return;
+        }
+
+        if (!self.query_limiter.checkAndRecord(conn.getClientIp())) {
+            metrics.rateLimited();
+            self.sendClosed(conn, sub_id, "rate-limited: too many queries");
             return;
         }
 
@@ -611,6 +626,29 @@ pub const Handler = struct {
 
         if (sub_id.len == 0 or sub_id.len > 64) {
             self.sendNegErr(conn, sub_id, "error: invalid subscription ID");
+            return;
+        }
+
+        if (!self.query_limiter.checkAndRecord(conn.getClientIp())) {
+            metrics.rateLimited();
+            self.sendNegErr(conn, sub_id, "rate-limited: too many queries");
+            return;
+        }
+
+        // Reconciliation reveals which event IDs the relay holds, so it must
+        // honor the same auth gate as REQ/COUNT.
+        if (self.config.auth_required and !conn.isAuthenticated()) {
+            self.sendNegErr(conn, sub_id, "auth-required: authentication required");
+            return;
+        }
+
+        // Each session buffers up to negentropy_max_sync_events in memory; cap the
+        // number of concurrent sessions so a connection cannot exhaust memory by
+        // opening many distinct sub_ids. Re-opening an existing sub_id is allowed.
+        if (conn.getNegSession(sub_id) == null and
+            conn.neg_sessions.count() >= self.config.max_subscriptions)
+        {
+            self.sendNegErr(conn, sub_id, "blocked: too many negentropy sessions");
             return;
         }
 

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -419,7 +419,7 @@ pub const Handler = struct {
         const sub_id = sub_id_buf[0..sub_id_raw.len];
 
         if (!self.query_limiter.checkAndRecord(conn.getClientIp())) {
-            metrics.rateLimited();
+            metrics.queryRateLimited();
             self.sendClosed(conn, sub_id, "rate-limited: too many queries");
             return;
         }
@@ -513,7 +513,7 @@ pub const Handler = struct {
         }
 
         if (!self.query_limiter.checkAndRecord(conn.getClientIp())) {
-            metrics.rateLimited();
+            metrics.queryRateLimited();
             self.sendClosed(conn, sub_id, "rate-limited: too many queries");
             return;
         }
@@ -630,7 +630,7 @@ pub const Handler = struct {
         }
 
         if (!self.query_limiter.checkAndRecord(conn.getClientIp())) {
-            metrics.rateLimited();
+            metrics.queryRateLimited();
             self.sendNegErr(conn, sub_id, "rate-limited: too many queries");
             return;
         }
@@ -646,7 +646,7 @@ pub const Handler = struct {
         // number of concurrent sessions so a connection cannot exhaust memory by
         // opening many distinct sub_ids. Re-opening an existing sub_id is allowed.
         if (conn.getNegSession(sub_id) == null and
-            conn.neg_sessions.count() >= self.config.max_subscriptions)
+            conn.neg_sessions.count() >= self.config.max_neg_sessions)
         {
             self.sendNegErr(conn, sub_id, "blocked: too many negentropy sessions");
             return;

--- a/src/main.zig
+++ b/src/main.zig
@@ -174,7 +174,10 @@ pub fn main(init: std.process.Init) !void {
     var event_limiter = rate_limiter.EventRateLimiter.init(allocator, config.events_per_minute);
     defer event_limiter.deinit();
 
-    var handler = Handler.init(allocator, &config, &store, &subs, &broadcaster, &event_limiter, &g_shutdown, &mgmt_store);
+    var query_limiter = rate_limiter.EventRateLimiter.init(allocator, config.queries_per_minute);
+    defer query_limiter.deinit();
+
+    var handler = Handler.init(allocator, &config, &store, &subs, &broadcaster, &event_limiter, &query_limiter, &g_shutdown, &mgmt_store);
 
     var server: Server = undefined;
     try server.init(allocator, init.io, &config, &handler, &subs, &g_shutdown, &nip86_handler);
@@ -218,7 +221,7 @@ pub fn main(init: std.process.Init) !void {
     // Mandatory: the cleanup thread also drives graceful shutdown (it calls
     // server.stop() after observing the flag the signal handler sets). Without it
     // running, a SIGINT/SIGTERM would set the flag but nothing would unblock listen().
-    const cleanup_thread = try std.Thread.spawn(.{}, storeCleanupThread, .{ &server, &store, &config, &subs, &g_shutdown, &server.conn_limiter, &event_limiter });
+    const cleanup_thread = try std.Thread.spawn(.{}, storeCleanupThread, .{ &server, &store, &config, &subs, &g_shutdown, &server.conn_limiter, &event_limiter, &query_limiter });
     defer cleanup_thread.join();
 
     try server.listen();
@@ -226,7 +229,7 @@ pub fn main(init: std.process.Init) !void {
     std.log.info("Shutdown complete", .{});
 }
 
-fn storeCleanupThread(server: *Server, store: *Store, config: *const Config, subs: *Subscriptions, shutdown: *std.atomic.Value(bool), conn_limiter: *rate_limiter.ConnectionLimiter, event_limiter: *rate_limiter.EventRateLimiter) void {
+fn storeCleanupThread(server: *Server, store: *Store, config: *const Config, subs: *Subscriptions, shutdown: *std.atomic.Value(bool), conn_limiter: *rate_limiter.ConnectionLimiter, event_limiter: *rate_limiter.EventRateLimiter, query_limiter: *rate_limiter.EventRateLimiter) void {
     const check_interval_ns: u64 = std.time.ns_per_s;
     const hour_checks: u64 = 3600;
     const limiter_cleanup_checks: u64 = 300;
@@ -256,6 +259,7 @@ fn storeCleanupThread(server: *Server, store: *Store, config: *const Config, sub
         if (checks % limiter_cleanup_checks == 0) {
             conn_limiter.cleanup();
             event_limiter.cleanup();
+            query_limiter.cleanup();
         }
 
         if (checks < hour_checks) continue;

--- a/src/rate_limiter.zig
+++ b/src/rate_limiter.zig
@@ -208,8 +208,16 @@ pub const IpFilter = struct {
         if (map.contains(ip)) return true;
 
         var iter = map.keyIterator();
-        while (iter.next()) |prefix| {
-            if (std.mem.startsWith(u8, ip, prefix.*)) {
+        while (iter.next()) |entry| {
+            const e = entry.*;
+            // Only an entry written as an explicit prefix (trailing '.' or ':')
+            // matches by prefix, and then only at an octet/group boundary. A full
+            // address like "10.0.0.5" must match exactly, never as a prefix of
+            // "10.0.0.50", otherwise an allowlist entry silently admits a whole
+            // range and a blocklist entry over-blocks unrelated addresses.
+            if (e.len > 0 and (e[e.len - 1] == '.' or e[e.len - 1] == ':') and
+                std.mem.startsWith(u8, ip, e))
+            {
                 return true;
             }
         }
@@ -224,18 +232,22 @@ pub fn extractClientIp(
     trust_proxy: bool,
 ) []const u8 {
     if (trust_proxy) {
-        if (real_ip) |ip| {
-            if (ip.len > 0) {
-                return normalizeIp(ip);
-            }
-        }
-
+        // Prefer X-Forwarded-For: the trusted proxy appends the address it
+        // actually received from, so the rightmost entry is proxy-controlled.
+        // X-Real-IP is only a fallback because a client can set it when the proxy
+        // does not, which would let it spoof the key used for every per-IP control.
         if (forwarded_for) |xff| {
             if (xff.len > 0) {
                 if (std.mem.lastIndexOf(u8, xff, ",")) |comma| {
                     return normalizeIp(std.mem.trim(u8, xff[comma + 1 ..], " "));
                 }
                 return normalizeIp(xff);
+            }
+        }
+
+        if (real_ip) |ip| {
+            if (ip.len > 0) {
+                return normalizeIp(ip);
             }
         }
     }
@@ -263,10 +275,42 @@ fn normalizeIp(ip: []const u8) []const u8 {
 }
 
 test "extractClientIp" {
+    // Proxy headers ignored unless trust_proxy is set.
     try std.testing.expectEqualStrings("192.168.1.1", extractClientIp(null, null, "192.168.1.1:8080", false));
     try std.testing.expectEqualStrings("10.0.0.1", extractClientIp("1.2.3.4", null, "10.0.0.1:8080", false));
+    // Trusted: rightmost X-Forwarded-For entry (the hop the proxy appended).
     try std.testing.expectEqualStrings("10.0.0.1", extractClientIp("1.2.3.4, 10.0.0.1", null, "127.0.0.1:8080", true));
-    try std.testing.expectEqualStrings("5.6.7.8", extractClientIp("1.2.3.4", "5.6.7.8", "127.0.0.1:8080", true));
+    // X-Forwarded-For is preferred over client-settable X-Real-IP.
+    try std.testing.expectEqualStrings("1.2.3.4", extractClientIp("1.2.3.4", "5.6.7.8", "127.0.0.1:8080", true));
+    // X-Real-IP is used only when no X-Forwarded-For is present.
+    try std.testing.expectEqualStrings("5.6.7.8", extractClientIp(null, "5.6.7.8", "127.0.0.1:8080", true));
+}
+
+test "IpFilter full address matches exactly, not as a prefix" {
+    var f = IpFilter.init(std.testing.allocator);
+    defer f.deinit();
+    try f.loadWhitelist("10.0.0.5");
+    try std.testing.expect(f.isAllowed("10.0.0.5"));
+    // The bug: "10.0.0.5" must not admit "10.0.0.50"/"10.0.0.55".
+    try std.testing.expect(!f.isAllowed("10.0.0.50"));
+    try std.testing.expect(!f.isAllowed("10.0.0.55"));
+}
+
+test "IpFilter trailing-dot entry is an explicit subnet prefix" {
+    var f = IpFilter.init(std.testing.allocator);
+    defer f.deinit();
+    try f.loadWhitelist("10.0.0.");
+    try std.testing.expect(f.isAllowed("10.0.0.5"));
+    try std.testing.expect(f.isAllowed("10.0.0.50"));
+    try std.testing.expect(!f.isAllowed("10.0.1.5"));
+}
+
+test "IpFilter blacklist does not over-block on shared prefix" {
+    var f = IpFilter.init(std.testing.allocator);
+    defer f.deinit();
+    try f.loadBlacklist("1.2.3.4");
+    try std.testing.expect(!f.isAllowed("1.2.3.4"));
+    try std.testing.expect(f.isAllowed("1.2.3.40"));
 }
 
 test "normalizeIp" {

--- a/src/rate_limiter.zig
+++ b/src/rate_limiter.zig
@@ -225,10 +225,10 @@ pub const IpFilter = struct {
         if (map.contains(ip)) return true;
 
         var iter = map.keyIterator();
-        while (iter.next()) |entry| {
-            const e = entry.*;
-            if (e.len == 0) continue;
-            const last = e[e.len - 1];
+        while (iter.next()) |key| {
+            const prefix = key.*;
+            if (prefix.len == 0) continue;
+            const last = prefix[prefix.len - 1];
             // Only an entry written as an explicit prefix (trailing '.' or ':')
             // matches by prefix, and then only at an octet/group boundary. A full
             // address like "10.0.0.5" must match exactly, never as a prefix of
@@ -237,8 +237,8 @@ pub const IpFilter = struct {
             if (last != '.' and last != ':') continue;
             // A complete IPv6 address can end in ':' (via "::"); such an entry is an
             // exact match (handled above), not a subnet prefix.
-            if (last == ':' and isCompleteIp6(e)) continue;
-            if (std.mem.startsWith(u8, ip, e)) return true;
+            if (last == ':' and isCompleteIp6(prefix)) continue;
+            if (std.mem.startsWith(u8, ip, prefix)) return true;
         }
         return false;
     }
@@ -290,7 +290,22 @@ pub fn extractClientIp(
 fn bucketKey(ip: []const u8, buf: *[19]u8) []const u8 {
     if (std.mem.count(u8, ip, ":") < 2) return ip;
     const addr = std.Io.net.Ip6Address.parse(ip, 0) catch return ip;
-    const hex = std.fmt.bytesToHex(addr.bytes[0..8].*, .lower);
+    const b = addr.bytes;
+
+    // IPv4-mapped (::ffff:a.b.c.d): key on the embedded IPv4 so a dual-stack
+    // listener does not collapse every IPv4 client into one /64 bucket.
+    var zero_prefix = true;
+    for (b[0..10]) |x| {
+        if (x != 0) {
+            zero_prefix = false;
+            break;
+        }
+    }
+    if (zero_prefix and b[10] == 0xff and b[11] == 0xff) {
+        return std.fmt.bufPrint(buf, "{d}.{d}.{d}.{d}", .{ b[12], b[13], b[14], b[15] }) catch ip;
+    }
+
+    const hex = std.fmt.bytesToHex(b[0..8].*, .lower);
     return std.fmt.bufPrint(buf, "{s}/64", .{hex}) catch ip;
 }
 

--- a/src/rate_limiter.zig
+++ b/src/rate_limiter.zig
@@ -31,11 +31,13 @@ pub const ConnectionLimiter = struct {
         self.ip_buckets.deinit();
     }
 
-    pub fn canConnect(self: *ConnectionLimiter, ip: []const u8) bool {
+    pub fn canConnect(self: *ConnectionLimiter, raw_ip: []const u8) bool {
         const io = nostr.io.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
 
+        var key_buf: [19]u8 = undefined;
+        const ip = bucketKey(raw_ip, &key_buf);
         if (self.ip_buckets.get(ip)) |bucket| {
             return bucket.connection_count < self.max_connections_per_ip;
         }
@@ -45,13 +47,15 @@ pub const ConnectionLimiter = struct {
     /// Atomically check the per-IP limit and increment in one locked section.
     /// Returns false (without incrementing) if the IP is already at the limit,
     /// closing the canConnect/addConnection check-then-act race.
-    pub fn tryAcquireConnection(self: *ConnectionLimiter, ip: []const u8) bool {
+    pub fn tryAcquireConnection(self: *ConnectionLimiter, raw_ip: []const u8) bool {
         const io = nostr.io.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
 
         const now = nostr.io.timestamp();
 
+        var key_buf: [19]u8 = undefined;
+        const ip = bucketKey(raw_ip, &key_buf);
         if (self.ip_buckets.getPtr(ip)) |bucket| {
             if (bucket.connection_count >= self.max_connections_per_ip) return false;
             bucket.connection_count += 1;
@@ -70,11 +74,13 @@ pub const ConnectionLimiter = struct {
         return true;
     }
 
-    pub fn removeConnection(self: *ConnectionLimiter, ip: []const u8) void {
+    pub fn removeConnection(self: *ConnectionLimiter, raw_ip: []const u8) void {
         const io = nostr.io.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
 
+        var key_buf: [19]u8 = undefined;
+        const ip = bucketKey(raw_ip, &key_buf);
         if (self.ip_buckets.getPtr(ip)) |bucket| {
             if (bucket.connection_count > 0) {
                 bucket.connection_count -= 1;
@@ -203,6 +209,17 @@ pub const IpFilter = struct {
         return true;
     }
 
+    pub fn isTrustedProxy(self: *IpFilter, ip: []const u8) bool {
+        const io = nostr.io.io();
+        self.mutex.lockUncancelable(io);
+        defer self.mutex.unlock(io);
+
+        // An empty trusted-proxy set trusts every peer; otherwise only configured
+        // IPs/prefixes are honored.
+        if (!self.whitelist_enabled) return true;
+        return self.matchesPrefix(&self.whitelist, ip);
+    }
+
     fn matchesPrefix(self: *IpFilter, map: *std.StringHashMap(void), ip: []const u8) bool {
         _ = self;
         if (map.contains(ip)) return true;
@@ -210,20 +227,27 @@ pub const IpFilter = struct {
         var iter = map.keyIterator();
         while (iter.next()) |entry| {
             const e = entry.*;
+            if (e.len == 0) continue;
+            const last = e[e.len - 1];
             // Only an entry written as an explicit prefix (trailing '.' or ':')
             // matches by prefix, and then only at an octet/group boundary. A full
             // address like "10.0.0.5" must match exactly, never as a prefix of
             // "10.0.0.50", otherwise an allowlist entry silently admits a whole
             // range and a blocklist entry over-blocks unrelated addresses.
-            if (e.len > 0 and (e[e.len - 1] == '.' or e[e.len - 1] == ':') and
-                std.mem.startsWith(u8, ip, e))
-            {
-                return true;
-            }
+            if (last != '.' and last != ':') continue;
+            // A complete IPv6 address can end in ':' (via "::"); such an entry is an
+            // exact match (handled above), not a subnet prefix.
+            if (last == ':' and isCompleteIp6(e)) continue;
+            if (std.mem.startsWith(u8, ip, e)) return true;
         }
         return false;
     }
 };
+
+fn isCompleteIp6(text: []const u8) bool {
+    _ = std.Io.net.Ip6Address.parse(text, 0) catch return false;
+    return true;
+}
 
 pub fn extractClientIp(
     forwarded_for: ?[]const u8,
@@ -238,10 +262,14 @@ pub fn extractClientIp(
         // does not, which would let it spoof the key used for every per-IP control.
         if (forwarded_for) |xff| {
             if (xff.len > 0) {
-                if (std.mem.lastIndexOf(u8, xff, ",")) |comma| {
-                    return normalizeIp(std.mem.trim(u8, xff[comma + 1 ..], " "));
-                }
-                return normalizeIp(xff);
+                const segment = if (std.mem.lastIndexOf(u8, xff, ",")) |comma|
+                    xff[comma + 1 ..]
+                else
+                    xff;
+                const entry = std.mem.trim(u8, segment, " \t");
+                // A trailing comma or whitespace-only segment trims to empty; fall
+                // back to X-Real-IP, then remote_addr, instead of one shared key.
+                if (entry.len > 0) return normalizeIp(entry);
             }
         }
 
@@ -253,6 +281,17 @@ pub fn extractClientIp(
     }
 
     return normalizeIp(remote_addr);
+}
+
+// Derive the per-IP rate-limit bucket key. IPv6 clients are keyed on their /64
+// prefix so a client rotating addresses within a single /64 allocation cannot get
+// fresh allowance per address or bloat the bucket map. IPv4 and non-address
+// strings pass through unchanged. `buf` backs the returned slice for the IPv6 case.
+fn bucketKey(ip: []const u8, buf: *[19]u8) []const u8 {
+    if (std.mem.count(u8, ip, ":") < 2) return ip;
+    const addr = std.Io.net.Ip6Address.parse(ip, 0) catch return ip;
+    const hex = std.fmt.bytesToHex(addr.bytes[0..8].*, .lower);
+    return std.fmt.bufPrint(buf, "{s}/64", .{hex}) catch ip;
 }
 
 fn normalizeIp(ip: []const u8) []const u8 {
@@ -357,7 +396,8 @@ pub const EventRateLimiter = struct {
 
     pub fn checkAndRecord(self: *EventRateLimiter, ip: []const u8) bool {
         if (self.events_per_minute == 0) return true;
-        return self.checkAndRecordAt(ip, nostr.io.timestamp());
+        var buf: [19]u8 = undefined;
+        return self.checkAndRecordAt(bucketKey(ip, &buf), nostr.io.timestamp());
     }
 
     fn checkAndRecordAt(self: *EventRateLimiter, ip: []const u8, now: i64) bool {

--- a/src/relay_metrics.zig
+++ b/src/relay_metrics.zig
@@ -11,6 +11,7 @@ var events_rejected = std.atomic.Value(u64).init(0);
 var events_broadcast = std.atomic.Value(u64).init(0);
 var reqs_total = std.atomic.Value(u64).init(0);
 var rate_limited = std.atomic.Value(u64).init(0);
+var query_rate_limited = std.atomic.Value(u64).init(0);
 
 pub fn connectionOpened() void {
     _ = connections_total.fetchAdd(1, .monotonic);
@@ -36,6 +37,10 @@ pub fn rateLimited() void {
     _ = rate_limited.fetchAdd(1, .monotonic);
 }
 
+pub fn queryRateLimited() void {
+    _ = query_rate_limited.fetchAdd(1, .monotonic);
+}
+
 fn metric(w: anytype, name: []const u8, help: []const u8, kind: []const u8, value: u64) !void {
     try w.print("# HELP {s} {s}\n# TYPE {s} {s}\n{s} {d}\n", .{ name, help, name, kind, name, value });
 }
@@ -50,6 +55,7 @@ pub fn write(w: anytype, active_connections: u64) !void {
     try metric(w, "wisp_events_broadcast_total", "Events delivered to matching subscriptions", "counter", events_broadcast.load(.monotonic));
     try metric(w, "wisp_req_total", "REQ subscription messages received", "counter", reqs_total.load(.monotonic));
     try metric(w, "wisp_rate_limited_total", "Connections/events rejected by rate or connection limits", "counter", rate_limited.load(.monotonic));
+    try metric(w, "wisp_query_rate_limited_total", "Query messages (REQ/COUNT/NEG_OPEN) rejected by the query rate limit", "counter", query_rate_limited.load(.monotonic));
 }
 
 test write {

--- a/src/server.zig
+++ b/src/server.zig
@@ -27,6 +27,7 @@ pub const App = struct {
     nip86_handler: *Nip86Handler,
     conn_limiter: *rate_limiter.ConnectionLimiter,
     ip_filter: *rate_limiter.IpFilter,
+    trusted_proxies: *rate_limiter.IpFilter,
     next_id: *std.atomic.Value(u64),
 
     // httpz requires this declaration to enable WebSocket upgrades.
@@ -143,6 +144,10 @@ pub const App = struct {
     fn clientIp(app: App, req: *httpz.Request, res: *httpz.Response, buf: *[64]u8) []const u8 {
         const socket_ip = formatPeerIp(res.conn.address, buf);
         if (!app.config.trust_proxy) return socket_ip;
+        // Only honor forwarded headers when the socket peer is a configured trusted
+        // proxy; otherwise an attacker hitting the backend directly could forge them
+        // to spoof any client IP. An empty trusted_proxies set trusts any peer.
+        if (!app.trusted_proxies.isTrustedProxy(socket_ip)) return socket_ip;
         const xff = req.header("x-forwarded-for");
         const xrip = req.header("x-real-ip");
         return rate_limiter.extractClientIp(xff, xrip, socket_ip, true);
@@ -329,6 +334,7 @@ pub const Server = struct {
     httpz_server: httpz.Server(App),
     conn_limiter: rate_limiter.ConnectionLimiter,
     ip_filter: rate_limiter.IpFilter,
+    trusted_proxy_filter: rate_limiter.IpFilter,
     next_id: std.atomic.Value(u64),
 
     pub fn init(
@@ -347,6 +353,8 @@ pub const Server = struct {
         self.ip_filter = rate_limiter.IpFilter.init(allocator);
         try self.ip_filter.loadWhitelist(config.ip_whitelist);
         try self.ip_filter.loadBlacklist(config.ip_blacklist);
+        self.trusted_proxy_filter = rate_limiter.IpFilter.init(allocator);
+        try self.trusted_proxy_filter.loadWhitelist(config.trusted_proxies);
 
         const app = App{
             .allocator = allocator,
@@ -357,6 +365,7 @@ pub const Server = struct {
             .nip86_handler = nip86_handler,
             .conn_limiter = &self.conn_limiter,
             .ip_filter = &self.ip_filter,
+            .trusted_proxies = &self.trusted_proxy_filter,
             .next_id = &self.next_id,
         };
 
@@ -413,5 +422,6 @@ pub const Server = struct {
         self.httpz_server.deinit();
         self.conn_limiter.deinit();
         self.ip_filter.deinit();
+        self.trusted_proxy_filter.deinit();
     }
 };

--- a/wisp.toml.example
+++ b/wisp.toml.example
@@ -52,6 +52,11 @@ idle_seconds = 300
 
 [security]
 # trust_proxy = false  # set true when running behind a reverse proxy (see docs/deployment.md)
+# Honor X-Forwarded-For/X-Real-IP only when trust_proxy is true. The proxy MUST
+# append the real client to X-Forwarded-For and the backend port MUST NOT be
+# directly reachable, otherwise clients can forge these headers to spoof any IP.
+# Restrict which peers are trusted to a proxy IP/prefix list; empty trusts any peer.
+# trusted_proxies = "127.0.0.1,10.0.0."
 # max_connections_per_ip = 10
 # ip_whitelist = "192.168.1,10.0.0"
 # ip_blacklist = ""
@@ -68,6 +73,9 @@ admin = ""  # your hex pubkey (use `zig-out/bin/wisp help` for npub support via 
 [negentropy]
 enabled = true
 max_sync_events = 1000000
+# Concurrent reconciliation sessions per connection. Each can buffer up to
+# max_sync_events IDs, so keep this small.
+max_sessions = 4
 
 [management]
 # NIP-86 relay management. Comma-separated hex pubkeys allowed to run admin commands.

--- a/wisp.toml.example
+++ b/wisp.toml.example
@@ -39,6 +39,8 @@ query_limit_max = 5000
 
 [rate_limits]
 events_per_minute = 60
+# Per-IP limit on expensive query messages (REQ/COUNT/NEG_OPEN). 0 disables.
+queries_per_minute = 300
 
 [timeouts]
 idle_seconds = 300

--- a/wisp.toml.example
+++ b/wisp.toml.example
@@ -58,7 +58,9 @@ idle_seconds = 300
 # Restrict which peers are trusted to a proxy IP/prefix list; empty trusts any peer.
 # trusted_proxies = "127.0.0.1,10.0.0."
 # max_connections_per_ip = 10
-# ip_whitelist = "192.168.1,10.0.0"
+# Prefix entries must end in '.' (IPv4) or ':' (IPv6); entries without a trailing
+# separator match exactly. CIDR and '*' wildcards are not supported.
+# ip_whitelist = "192.168.1.,10.0.0."
 # ip_blacklist = ""
 
 [spider]


### PR DESCRIPTION
From the pre-v1 security review. Fixes the two HIGH findings and two real MEDIUMs; the remaining LOW/MEDIUM notes are filed as follow-up issues.

## HIGH — Unauthenticated query-amplification DoS (no rate limit on REQ/COUNT/NEG_OPEN)
Only `handleEvent` was rate limited; REQ/COUNT/NEG_OPEN each drive real LMDB work (a REQ streams up to `query_limit_max` events, COUNT scans every filter, NEG_OPEN loads up to `negentropy_max_sync_events` hashes) with no throttle. A single client could pin worker threads at line rate.

**Fix:** a dedicated per-IP token-bucket `query_limiter` (config `queries_per_minute`, default 300, 0 disables), checked at the top of `handleReq`/`handleCount`/`handleNegOpen`. Verified live: with `queries_per_minute=3`, 8 REQs → 3 served, 5 rate-limited.

## HIGH — IP allowlist/blocklist matched by unbounded prefix
`matchesPrefix` used raw `startsWith`, so allowlisting `10.0.0.5` also admitted `10.0.0.50`/`10.0.0.55…` (authorization bypass) and blocklisting `1.2.3.4` over-blocked `1.2.3.40…`.

**Fix:** exact match by default; an entry only matches by prefix when written as an explicit subnet prefix (trailing `.` or `:`). Covered by new tests.

## MEDIUM — Negentropy ignored `auth_required` and had no session cap
`handleNegOpen`/`handleNegMsg` skipped the auth gate that REQ/COUNT enforce (reconciliation leaks which event IDs the relay holds), and `addNegSession` had no per-connection cap (each session buffers up to `negentropy_max_sync_events`).

**Fix:** apply the `auth_required` gate to NEG_OPEN, and cap concurrent sessions per connection at `max_subscriptions` (re-opening an existing sub_id still allowed).

## MEDIUM — `trust_proxy` preferred client-settable `X-Real-IP`
`extractClientIp` returned `X-Real-IP` before `X-Forwarded-For`. When the proxy sets only XFF (common), `X-Real-IP` is client-controlled, letting a client spoof the key behind every per-IP control (rate limits, IP filter, NIP-86 blocklist).

**Fix:** prefer the proxy-appended rightmost `X-Forwarded-For`; use `X-Real-IP` only as a fallback. Tests updated.

## CI
The concurrency and spider tests hammer one IP and already raise `WISP_EVENTS_PER_MINUTE`; they now also set `WISP_QUERIES_PER_MINUTE=100000`. Other suites are low-volume (negentropy N=8, integration ≤9 REQs) and stay within defaults.

## Reviewed clean (no change)
NIP-42 auth, NIP-09 deletion authz, NIP-70 protected events, NIP-86 admin gating, the PoW scanners; no secrets/injection.

26/26 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable per-IP rate limiting for query operations to help prevent abuse and protect server resources. Limits can be set via configuration file or environment variables.

* **Bug Fixes**
  * Fixed IP filtering logic to accurately match whitelisted and blacklisted addresses, preventing unintended blocking.

* **Improvements**
  * Enhanced trusted proxy header handling for more accurate client IP detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->