### PR TITLE
Don't send CLOSED in reply to client CLOSE (NIP-01)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Clone nostr-bench
-        run: git clone --depth 1 --branch v0.2.0 https://github.com/privkeyio/nostr-bench ../nostr-bench
+        run: git clone --depth 1 --branch v0.2.1 https://github.com/privkeyio/nostr-bench ../nostr-bench
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y liblmdb-dev libsecp256k1-dev libssl-dev netcat-openbsd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Updated libnostr-z to v0.3.3
 - Updated libnostr-z to v0.1.6
 
 ### Fixed
 
+- No longer send `CLOSED` in reply to a client `CLOSE` (NIP-01)
 - Fixed config file argument parsing and inline comment handling
 - Fixed spider connection handling
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,8 +11,8 @@
             .hash = "websocket-0.1.0-ZPISdV_aBACU9pGuvrTQ2z8uxz_Sp8JnJgQaiGKQIx1l",
         },
         .nostr = .{
-            .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.0.tar.gz",
-            .hash = "nostr-0.3.0-JY6OcJJ0DwDrcooJo6viPaiDg6ohNPie0wV10XykgQPE",
+            .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.2.tar.gz",
+            .hash = "nostr-0.3.2-JY6OcPiYDwCqpbCqr3dTI3IlRd2055ALPPUUmV0n3eCs",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Pins the same websocket.zig commit.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,8 +11,8 @@
             .hash = "websocket-0.1.0-ZPISdV_aBACU9pGuvrTQ2z8uxz_Sp8JnJgQaiGKQIx1l",
         },
         .nostr = .{
-            .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.2.tar.gz",
-            .hash = "nostr-0.3.2-JY6OcPiYDwCqpbCqr3dTI3IlRd2055ALPPUUmV0n3eCs",
+            .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.3.tar.gz",
+            .hash = "nostr-0.3.3-JY6OcOSaDwCoLI1RJOisJcxXrdzzP3Z57GyVBoC0wx2-",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Pins the same websocket.zig commit.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.4.0",
+    .version = "0.4.1",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -501,7 +501,9 @@ pub const Handler = struct {
     fn handleClose(self: *Handler, conn: *Connection, msg: *nostr.ClientMsg) void {
         const sub_id = msg.subscriptionId();
         self.subs.unsubscribe(conn, sub_id);
-        self.sendClosed(conn, sub_id, "");
+        // Per NIP-01, CLOSED is only sent when the relay ends a subscription on
+        // its own initiative; a client CLOSE is acknowledged by silently
+        // dropping the subscription.
     }
 
     fn handleCount(self: *Handler, conn: *Connection, msg: *nostr.ClientMsg) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -150,7 +150,7 @@ pub fn main(init: std.process.Init) !void {
     try nostr.init();
     defer nostr.cleanup();
 
-    std.log.info("Wisp v0.4.0 starting", .{});
+    std.log.info("Wisp v0.4.1 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s}", .{config.storage_path});
 


### PR DESCRIPTION
## Problem

`handleClose` replied to a client `CLOSE` with `["CLOSED", <sub_id>, ""]`. NIP-01 specifies `CLOSED` is sent only when the relay refuses a `REQ` or ends a subscription **on its own initiative before the client disconnects or sends a CLOSE** — not as an acknowledgement of a client `CLOSE`. nostr-rs-relay and strfry both drop the subscription silently.

The spurious `CLOSED` desynchronizes clients that send `CLOSE` and then expect the next message to be the reply to their next request: e.g. a benchmark doing REQ→EOSE→CLOSE→EVENT reads the leftover `CLOSED` instead of its `OK`.

## Fix

Drop the subscription silently on `CLOSE`; no response frame. (`sendClosed` is still used for REQ refusals and server-initiated closes.)

## Verification

Probed with a raw WebSocket client: after `CLOSE` the relay now sends nothing (previously `["CLOSED","sub",""]`). nostr-bench mixed read/write test goes from 66.7% to 100% success.