### PR TITLE
Bump Dockerfile Zig to 0.16.0 to match build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     liblmdb-dev libsecp256k1-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://ziglang.org/download/0.15.2/zig-$(uname -m)-linux-0.15.2.tar.xz | \
-    tar -xJ -C /opt && ln -s /opt/zig-$(uname -m)-linux-0.15.2/zig /usr/local/bin/zig
+RUN curl -fsSL https://ziglang.org/download/0.16.0/zig-$(uname -m)-linux-0.16.0.tar.xz | \
+    tar -xJ -C /opt && ln -s /opt/zig-$(uname -m)-linux-0.16.0/zig /usr/local/bin/zig
 
 WORKDIR /src
 COPY . .


### PR DESCRIPTION
The Docker build in the release workflow downloads Zig 0.15.2, but the codebase and the native build jobs (`mlugg/setup-zig@v2` with `version: 0.16.0`) require Zig 0.16.0.

This caused every release's `docker` job to fail to compile:

- deps using `@Tuple`/`@Int` builtins not present in 0.15.2
- `src/main.zig` using `std.process.Init`
- `tests/test_lmdb.zig` using `std.Io.Threaded`

Because the `release` job depends on `docker`, the failure cascaded: GitHub Releases were created with no binary assets, and no GHCR image was published.

Bumping the Dockerfile to 0.16.0 matches the rest of the pipeline. Verified with a full local `docker build` (image builds and the same `zig build -Doptimize=ReleaseSafe` step that failed in CI now succeeds).