### PR TITLE
Swap test client from nak to noz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,13 @@ jobs:
           curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
           echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
 
-      - name: Install nak (nostr test client)
+      - name: Build noz (nostr test client)
+        env:
+          NOZ_VERSION: v0.2.0
         run: |
-          go install github.com/fiatjaf/nak@v0.19.12
-          echo "$HOME/go/bin" >> $GITHUB_PATH
+          git clone --depth 1 --branch "$NOZ_VERSION" https://github.com/privkeyio/noz "$RUNNER_TEMP/noz"
+          (cd "$RUNNER_TEMP/noz" && zig build -Doptimize=ReleaseFast)
+          echo "$RUNNER_TEMP/noz/zig-out/bin" >> $GITHUB_PATH
 
       - name: Build relay
         run: zig build
@@ -203,9 +206,9 @@ jobs:
             return 1
           }
           # grep -c exits 1 on zero matches; keep it from tripping `set -e`
-          count() { timeout 8 nak req -k 1 -l 50 ws://127.0.0.1:7785 2>/dev/null | grep -c '"kind"' || true; }
+          count() { timeout 8 noz req -k 1 -l 50 ws://127.0.0.1:7785 2>/dev/null | grep -c '"kind"' || true; }
           launch || { echo "crash relay not ready"; cat relay-crash.log 2>/dev/null; kill "$PID" 2>/dev/null; exit 1; }
-          for i in $(seq 1 10); do nak event --sec $sec -c "crash$i" ws://127.0.0.1:7785 >/dev/null 2>&1; done
+          for i in $(seq 1 10); do noz event --sec $sec -c "crash$i" ws://127.0.0.1:7785 >/dev/null 2>&1; done
           sleep 1
           before=$(count)
           # unclean kill, before the periodic 60s sync

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.4.1",
+    .version = "0.4.2",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -15,10 +15,12 @@
             .hash = "nostr-0.3.3-JY6OcOSaDwCoLI1RJOisJcxXrdzzP3Z57GyVBoC0wx2-",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
-        // websocket.zig's epoll worker pool. Pins the same websocket.zig commit.
+        // websocket.zig's epoll worker pool. privkeyio fork of karlseguin/http.zig
+        // (at 5f60277) carrying a fix for a lost websocket read event that leaked
+        // connections under load (CLOSE_WAIT); pending upstream PR.
         .httpz = .{
-            .url = "https://github.com/karlseguin/http.zig/archive/5f60277d3b3beffef86321869b13c57f7acc3c5b.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrJrbCACyokt2AARAG7Ul7h7xlZxL7BYAdpsAs1_-",
+            .url = "https://github.com/privkeyio/http.zig/archive/061104c8e5a67dd22941da2d5f38f011550f5bc0.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrJLlCAClBJ52r0KravlJNK8UVNOSxnb4ppTlC_WG",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,7 +17,8 @@
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Pinned to privkeyio fork commit
         // 061104c (upstream karlseguin 5f60277 + a fix for a lost websocket read
-        // event that leaked connections under load, CLOSE_WAIT); pending upstream PR.
+        // event that leaked connections under load, CLOSE_WAIT); upstream PR
+        // karlseguin/http.zig#212.
         .httpz = .{
             .url = "https://github.com/privkeyio/http.zig/archive/061104c8e5a67dd22941da2d5f38f011550f5bc0.tar.gz",
             .hash = "httpz-0.0.0-PNVzrJLlCAClBJ52r0KravlJNK8UVNOSxnb4ppTlC_WG",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -15,9 +15,9 @@
             .hash = "nostr-0.3.3-JY6OcOSaDwCoLI1RJOisJcxXrdzzP3Z57GyVBoC0wx2-",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
-        // websocket.zig's epoll worker pool. privkeyio fork of karlseguin/http.zig
-        // (at 5f60277) carrying a fix for a lost websocket read event that leaked
-        // connections under load (CLOSE_WAIT); pending upstream PR.
+        // websocket.zig's epoll worker pool. Pinned to privkeyio fork commit
+        // 061104c (upstream karlseguin 5f60277 + a fix for a lost websocket read
+        // event that leaked connections under load, CLOSE_WAIT); pending upstream PR.
         .httpz = .{
             .url = "https://github.com/privkeyio/http.zig/archive/061104c8e5a67dd22941da2d5f38f011550f5bc0.tar.gz",
             .hash = "httpz-0.0.0-PNVzrJLlCAClBJ52r0KravlJNK8UVNOSxnb4ppTlC_WG",

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.4.0\"");
+    try w.writeAll(",\"version\":\"0.4.2\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});

--- a/src/store.zig
+++ b/src/store.zig
@@ -576,10 +576,19 @@ pub const QueryIterator = struct {
             self.started = true;
 
             const first_entry = switch (self.index_type) {
-                .kind, .pubkey => blk: {
-                    var seek_key: [72]u8 = undefined;
+                .kind, .pubkey, .tag => blk: {
+                    var seek_key: [73]u8 = undefined;
                     @memcpy(seek_key[0..self.prefix_len], self.prefix[0..self.prefix_len]);
-                    @memset(seek_key[self.prefix_len..][0..8], 0xFF);
+                    // Seek to the newest key at or below `until` for this prefix
+                    // so bounded queries don't scan the whole partition; with no
+                    // until, target the prefix max (all-0xFF timestamp).
+                    const until = self.filters[0].until();
+                    if (until > 0) {
+                        const until_be = @byteSwap(@as(u64, @bitCast(until)));
+                        @memcpy(seek_key[self.prefix_len..][0..8], std.mem.asBytes(&until_be));
+                    } else {
+                        @memset(seek_key[self.prefix_len..][0..8], 0xFF);
+                    }
                     @memset(seek_key[self.prefix_len + 8 ..][0..32], 0xFF);
                     const key_len = self.prefix_len + 40;
 
@@ -593,15 +602,12 @@ pub const QueryIterator = struct {
             };
 
             if (first_entry) |entry| {
-                // For the seeked indexes (kind/pubkey) the first entry is the
-                // greatest key <= the prefix max; if its prefix differs, there
+                // For the seeked indexes (kind/pubkey/tag) the first entry is the
+                // greatest key <= the seek target; if its prefix differs, there
                 // are no entries for this prefix (e.g. an empty kind whose seek
-                // fell back to .last on another kind). Without this, a
-                // wrong-prefix event leaks when skip_filter is set. The tag index
-                // is not seeked (it scans from .last), so the loop below does its
-                // prefix-checking there.
-                const seeked = self.index_type == .kind or self.index_type == .pubkey;
-                if (seeked and self.prefix_len > 0 and (entry.key.len < self.prefix_len or
+                // fell back to .last on another kind), so we must stop rather
+                // than leak a wrong-prefix event when skip_filter is set.
+                if (self.prefix_len > 0 and (entry.key.len < self.prefix_len or
                     !std.mem.eql(u8, entry.key[0..self.prefix_len], self.prefix[0..self.prefix_len])))
                 {
                     return null;

--- a/src/store.zig
+++ b/src/store.zig
@@ -517,7 +517,7 @@ pub const QueryIterator = struct {
                     iter.index_type = .pubkey;
                     @memcpy(iter.prefix[0..32], &authors[0]);
                     iter.prefix_len = 32;
-                    iter.skip_filter = (f.kinds() == null and f.ids() == null and !f.hasTagFilters() and f.search() == null);
+                    iter.skip_filter = (f.kinds() == null and f.ids() == null and !f.hasTagFilters() and f.search() == null and f.since() == 0 and f.until() == 0);
                     return iter;
                 }
             }
@@ -529,7 +529,7 @@ pub const QueryIterator = struct {
                         const kind_be = @byteSwap(@as(u32, @bitCast(kinds[0])));
                         @memcpy(iter.prefix[0..4], std.mem.asBytes(&kind_be));
                         iter.prefix_len = 4;
-                        iter.skip_filter = (f.search() == null);
+                        iter.skip_filter = (f.search() == null and f.since() == 0 and f.until() == 0);
                         return iter;
                     }
                 }
@@ -546,7 +546,7 @@ pub const QueryIterator = struct {
                                 iter.prefix[0] = tag_filter.letter;
                                 @memcpy(iter.prefix[1..33], &bytes);
                                 iter.prefix_len = 33;
-                                iter.skip_filter = (f.kinds() == null and f.authors() == null and f.ids() == null and f.search() == null);
+                                iter.skip_filter = (f.kinds() == null and f.authors() == null and f.ids() == null and f.search() == null and f.since() == 0 and f.until() == 0);
                             },
                             .string => {},
                         }
@@ -593,6 +593,19 @@ pub const QueryIterator = struct {
             };
 
             if (first_entry) |entry| {
+                // For the seeked indexes (kind/pubkey) the first entry is the
+                // greatest key <= the prefix max; if its prefix differs, there
+                // are no entries for this prefix (e.g. an empty kind whose seek
+                // fell back to .last on another kind). Without this, a
+                // wrong-prefix event leaks when skip_filter is set. The tag index
+                // is not seeked (it scans from .last), so the loop below does its
+                // prefix-checking there.
+                const seeked = self.index_type == .kind or self.index_type == .pubkey;
+                if (seeked and self.prefix_len > 0 and (entry.key.len < self.prefix_len or
+                    !std.mem.eql(u8, entry.key[0..self.prefix_len], self.prefix[0..self.prefix_len])))
+                {
+                    return null;
+                }
                 if (try self.processEntry(entry)) |json| {
                     return json;
                 }

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -44,6 +44,17 @@ pub --sec $SEC1 -k 1 -t t=wisptag -c "tagged"
 sleep 0.5
 chk "NIP-01 #t tag filter" 1 "$(req -k 1 -t t=wisptag)"
 
+# --- Tag index: a non-maximal binary tag must not leak the lexicographic-max event ---
+# #e (0x65) sorts below the #p (0x70) entries already stored. Before the tag-index
+# seek/prefix fix, a bare #e query returned the max-key (#p) event regardless of the
+# queried value; assert exact matches and a clean empty result for an unknown value.
+EREF=00000000000000000000000000000000000000000000000000000000deadbeef
+pub --sec $SEC1 -k 1 -e "$EREF" -c "references deadbeef"
+sleep 0.5
+chk "tag index #e returns only matching events" 1 "$(req -e "$EREF")"
+chk "tag index #e unknown value is empty" 0 \
+  "$(req -e 00000000000000000000000000000000000000000000000000000000feedface)"
+
 # --- NIP-09 deletion ---
 DID=$(idof --sec $SEC1 -c "delete me")
 sleep 0.5

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -3,15 +3,15 @@
 # wisp instance and asserts the responses, covering the NIPs wisp advertises.
 #
 # Usage: tests/integration.sh [relay-url]   (default ws://127.0.0.1:7777)
-# Requires: nak (https://github.com/fiatjaf/nak) on PATH.
+# Requires: noz (https://github.com/privkeyio/noz) on PATH.
 #
 # Exits non-zero if any assertion fails, so it can gate CI.
 set -u
 R="${1:-ws://127.0.0.1:7777}"
 SEC1=0000000000000000000000000000000000000000000000000000000000000001
 SEC2=0000000000000000000000000000000000000000000000000000000000000002
-PK1=$(nak key public $SEC1)
-PK2=$(nak key public $SEC2)
+PK1=$(noz key public $SEC1)
+PK2=$(noz key public $SEC2)
 pass=0
 fail=0
 
@@ -25,9 +25,9 @@ chk() { # desc expected actual
   fi
 }
 # count events returned by a REQ
-req() { timeout 10 nak req "$@" "$R" 2>/dev/null | grep -c '"kind"'; }
-pub() { nak event "$@" "$R" >/dev/null 2>&1; }
-idof() { nak event "$@" "$R" 2>/dev/null | grep -oE '"id":"[a-f0-9]{64}"' | head -1 | cut -d'"' -f4; }
+req() { timeout 10 noz req "$@" "$R" 2>/dev/null | grep -c '"kind"'; }
+pub() { noz event "$@" "$R" >/dev/null 2>&1; }
+idof() { noz event "$@" "$R" 2>/dev/null | grep -oE '"id":"[a-f0-9]{64}"' | head -1 | cut -d'"' -f4; }
 
 # --- NIP-01: publish + EVENT delivery on REQ (the core round-trip) ---
 ID=$(idof --sec $SEC1 -c "hello world")
@@ -59,7 +59,7 @@ pub --sec $SEC2 -k 0 --ts $((rbase + 1)) -c '{"name":"v2"}'
 sleep 0.5
 chk "NIP-16 replaceable kept single" 1 "$(req -k 0 -a "$PK2")"
 chk "NIP-16 replaceable keeps latest" "v2" \
-  "$(timeout 10 nak req -k 0 -a "$PK2" "$R" 2>/dev/null | grep -o 'v[12]' | head -1)"
+  "$(timeout 10 noz req -k 0 -a "$PK2" "$R" 2>/dev/null | grep -o 'v[12]' | head -1)"
 
 # --- NIP-16 ephemeral (kind 20000) not stored ---
 pub --sec $SEC1 -k 20000 -c "ephemeral"
@@ -90,12 +90,12 @@ pub --sec $SEC1 -k 1 -p "$PK2" -c "veggie wrap"
 sleep 0.5
 chk "NIP-50 search via tag index" 1 "$(req -k 1 -p "$PK2" --search tuna)"
 
-# --- NIP-45 COUNT (nak writes "<relay>: <n>" to stderr) ---
+# --- NIP-45 COUNT (noz prints the count to stdout) ---
 chk "NIP-45 COUNT returns a count" 1 \
-  "$(timeout 10 nak count -k 1 -t t=wisptag "$R" 2>&1 | awk '/: [0-9]+$/{print $NF}')"
+  "$(timeout 10 noz count -k 1 -t t=wisptag "$R" 2>/dev/null)"
 
 # --- NIP-11 relay information document ---
-INFO=$(timeout 10 nak relay "$R" 2>/dev/null)
+INFO=$(timeout 10 noz relay "$R" 2>/dev/null)
 present() { echo "$INFO" | grep -qE "\"$1\"[[:space:]]*:" && echo 1 || echo 0; }
 chk "NIP-11 info has name" 1 "$(present name)"
 chk "NIP-11 info has software" 1 "$(present software)"
@@ -116,7 +116,7 @@ chk "CORS preflight (OPTIONS) answered" 1 \
 # Explicit, distinct created_at values so ordering is deterministic (no
 # second-granularity ties that would otherwise break by event id).
 SEC3=0000000000000000000000000000000000000000000000000000000000000003
-PK3=$(nak key public $SEC3)
+PK3=$(noz key public $SEC3)
 base=$(($(date +%s) - 10))
 pub --sec $SEC3 --ts $base -c "lim1"
 pub --sec $SEC3 --ts $((base + 1)) -c "lim2"
@@ -124,7 +124,7 @@ pub --sec $SEC3 --ts $((base + 2)) -c "lim3"
 sleep 0.3
 chk "NIP-01 limit caps to N" 2 "$(req -k 1 -a "$PK3" -l 2)"
 chk "NIP-01 limit returns newest first" "lim3" \
-  "$(timeout 10 nak req -k 1 -a "$PK3" -l 2 "$R" 2>/dev/null | grep -o 'lim[0-9]' | head -1)"
+  "$(timeout 10 noz req -k 1 -a "$PK3" -l 2 "$R" 2>/dev/null | grep -o 'lim[0-9]' | head -1)"
 
 # --- NIP-40 expiration: expired rejected at publish, future-expiry kept ---
 now=$(date +%s)
@@ -148,7 +148,7 @@ sleep 0.3
 chk "created_at far-future event rejected" 0 "$(req -k 1 --search tslimitfuture -a "$PK1")"
 
 # --- NIP-70 protected events: rejected by default (no auth available) ---
-prot=$(nak event --sec $SEC1 -t '-' -c protected70 "$R" 2>&1 | grep -q success && echo ok || echo reject)
+prot=$(noz event --sec $SEC1 -t '-' -c protected70 "$R" 2>&1 | grep -q success && echo ok || echo reject)
 chk "NIP-70 protected event rejected without auth" reject "$prot"
 sleep 0.3
 chk "NIP-70 protected event not stored" 0 "$(req -k 1 --search protected70 -a "$PK1")"

--- a/tests/integration_concurrency.sh
+++ b/tests/integration_concurrency.sh
@@ -4,7 +4,7 @@
 # deadlocks, and crashes under load (it does not assert throughput).
 #
 # Usage: tests/integration_concurrency.sh <relay-ws-url>
-# Requires: nak on PATH. Exits non-zero if any assertion fails.
+# Requires: noz on PATH. Exits non-zero if any assertion fails.
 set -u
 R="${1:?relay url required}"
 SEC1=0000000000000000000000000000000000000000000000000000000000000001
@@ -24,17 +24,17 @@ chk() { # desc expected actual
 
 # Burst: N concurrent publishers and N concurrent subscribers.
 seq 1 $N | xargs -P 50 -I{} timeout 10 \
-  nak event --sec $SEC1 -c "concurrent{}" "$R" >/dev/null 2>&1
+  noz event --sec $SEC1 -c "concurrent{}" "$R" >/dev/null 2>&1
 seq 1 $N | xargs -P 50 -I{} timeout 10 \
-  nak req -k 1 -l 1 "$R" >/dev/null 2>&1
+  noz req -k 1 -l 1 "$R" >/dev/null 2>&1
 sleep 1
 
 # The relay must still answer NIP-11 (process alive, accept loop healthy).
 chk "relay responsive after $N concurrent connections" 1 \
-  "$(timeout 10 nak relay "$R" 2>/dev/null | grep -c '"name"')"
+  "$(timeout 10 noz relay "$R" 2>/dev/null | grep -c '"name"')"
 
 # ...and still function: publish then read back.
-id=$(timeout 10 nak event --sec $SEC1 -c "post-stress" "$R" 2>/dev/null \
+id=$(timeout 10 noz event --sec $SEC1 -c "post-stress" "$R" 2>/dev/null \
   | grep -oE '"id":"[a-f0-9]{64}"' | head -1 | cut -d'"' -f4)
 if [ -z "$id" ]; then
   echo "FAIL - relay did not accept an event after load"
@@ -43,7 +43,7 @@ if [ -z "$id" ]; then
 fi
 sleep 0.5
 chk "relay still serves REQ after load" 1 \
-  "$(timeout 10 nak req -i "$id" "$R" 2>/dev/null | grep -c '"kind"')"
+  "$(timeout 10 noz req -i "$id" "$R" 2>/dev/null | grep -c '"kind"')"
 
 echo "-----"
 echo "$pass passed, $fail failed"

--- a/tests/integration_management.sh
+++ b/tests/integration_management.sh
@@ -4,13 +4,13 @@
 # same <http-url> passed here (NIP-98 auth checks the URL).
 #
 # Usage: tests/integration_management.sh <http-url>   e.g. http://127.0.0.1:7781
-# Requires: nak, curl, sha256sum on PATH. Exits non-zero if any assertion fails.
+# Requires: noz, curl, sha256sum on PATH. Exits non-zero if any assertion fails.
 set -u
 HTTP="${1:?http url required}"
 WS="${HTTP/http:/ws:}"
 SEC1=0000000000000000000000000000000000000000000000000000000000000001
 SEC2=0000000000000000000000000000000000000000000000000000000000000002
-PK2=$(nak key public $SEC2)
+PK2=$(noz key public $SEC2)
 pass=0
 fail=0
 
@@ -24,14 +24,14 @@ chk() { # desc expected actual
   fi
 }
 has() { case "$1" in *"$2"*) echo 1 ;; *) echo 0 ;; esac; }
-published() { timeout 10 nak event --sec "$1" -c "$2" "$WS" 2>&1 | grep -c success; }
+published() { timeout 10 noz event --sec "$1" -c "$2" "$WS" 2>&1 | grep -c success; }
 
 # A NIP-86 call authorized with a NIP-98 (kind 27235) event signed by <sec>,
 # including the required payload (sha256 of the body) tag.
 call() { # sec body
   local sec=$1 body=$2 payload ev b64
   payload=$(printf '%s' "$body" | sha256sum | cut -d' ' -f1)
-  ev=$(timeout 10 nak event --sec "$sec" -k 27235 -t u="$HTTP" -t method=POST -t payload="$payload" -c "" 2>/dev/null)
+  ev=$(timeout 10 noz event --sec "$sec" -k 27235 -t u="$HTTP" -t method=POST -t payload="$payload" -c "" 2>/dev/null)
   b64=$(printf '%s' "$ev" | base64 -w0)
   curl -s --connect-timeout 5 --max-time 10 -X POST -H "Content-Type: application/nostr+json+rpc" \
     -H "Authorization: Nostr $b64" -d "$body" "$HTTP"

--- a/tests/integration_negentropy.sh
+++ b/tests/integration_negentropy.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # NIP-77 negentropy sync test. Seeds relay A, then uses negentropy
-# reconciliation (via `nak sync`) to replicate its events into empty relay B,
+# reconciliation (via `noz sync`) to replicate its events into empty relay B,
 # and asserts B received them.
 #
 # Usage: tests/integration_negentropy.sh <relay-a-url> <relay-b-url>
-# Requires: nak on PATH. Exits non-zero if any assertion fails.
+# Requires: noz on PATH. Exits non-zero if any assertion fails.
 set -u
 A="${1:?relay A url required}"
 B="${2:?relay B url required}"
@@ -22,28 +22,22 @@ chk() { # desc expected actual
     fail=$((fail + 1))
   fi
 }
-count() { timeout 10 nak req -k 1 -l 100 "$1" 2>/dev/null | grep -c '"kind"'; }
+count() { timeout 10 noz req -k 1 -l 100 "$1" 2>/dev/null | grep -c '"kind"'; }
 
 # distinct created_at values so every event is unique
 for i in $(seq 1 $N); do
-  timeout 6 nak event --sec $SEC1 --ts $((1700000000 + i)) -c "neg$i" "$A" >/dev/null 2>&1
+  timeout 6 noz event --sec $SEC1 --ts $((1700000000 + i)) -c "neg$i" "$A" >/dev/null 2>&1
 done
 sleep 1
 
 chk "relay A seeded" "$N" "$(count "$A")"
 chk "relay B empty before sync" 0 "$(count "$B")"
 
-# `nak sync` can publish only part of the reconciled set when the host is CPU
-# starved (a client-side flake, not a relay bug: the relay serves and stores
-# everything it is given). Negentropy sync is incremental, so retrying fills in
-# whatever is still missing until B converges on A's full set.
-got=0
-for attempt in 1 2 3 4 5; do
-  timeout 40 nak sync "$A" "$B" -k 1 >/dev/null 2>&1
-  sleep 1
-  got="$(count "$B")"
-  [ "$got" = "$N" ] && break
-done
+# noz sync drains the source fully before publishing, so a single pass copies
+# A's complete set into B (re-running is idempotent; the relay dedupes).
+timeout 40 noz sync "$A" "$B" -k 1 >/dev/null 2>&1
+sleep 1
+got="$(count "$B")"
 
 chk "NIP-77 negentropy replicated A into B" "$N" "$got"
 

--- a/tests/integration_restrict.sh
+++ b/tests/integration_restrict.sh
@@ -7,7 +7,7 @@
 #   pow       -> WISP_MIN_POW_DIFFICULTY=8
 #
 # Usage: tests/integration_restrict.sh <relay-url> <auth|protected|pow>
-# Requires: nak on PATH. Exits non-zero if any assertion fails.
+# Requires: noz on PATH. Exits non-zero if any assertion fails.
 set -u
 R="${1:?relay url required}"
 MODE="${2:?mode required (auth|protected|pow)}"
@@ -26,8 +26,8 @@ chk() { # desc expected actual
 }
 
 # publish and report ok|reject based on whether the relay accepted the event
-pubres() { # nak-args...
-  if timeout 10 nak event "$@" "$R" 2>&1 | grep -q 'success'; then echo ok; else echo reject; fi
+pubres() { # noz-args...
+  if timeout 10 noz event "$@" "$R" 2>&1 | grep -q 'success'; then echo ok; else echo reject; fi
 }
 
 case "$MODE" in

--- a/tests/integration_spider.sh
+++ b/tests/integration_spider.sh
@@ -9,13 +9,13 @@
 #   WISP_SPIDER_RELAYS=<source ws url>
 #
 # Usage: tests/integration_spider.sh <source-ws-url> <spider-ws-url>
-# Requires: nak on PATH. Exits non-zero if any assertion fails.
+# Requires: noz on PATH. Exits non-zero if any assertion fails.
 set -u
 SRC="${1:?source relay url required}"
 SPD="${2:?spider relay url required}"
 SEC1=0000000000000000000000000000000000000000000000000000000000000001
 SEC2=0000000000000000000000000000000000000000000000000000000000000002
-PK2=$(nak key public $SEC2)
+PK2=$(noz key public $SEC2)
 N=5
 pass=0
 fail=0
@@ -29,12 +29,12 @@ chk() { # desc expected actual
     fail=$((fail + 1))
   fi
 }
-count() { timeout 8 nak req -k 1 -a "$PK2" -l 50 "$1" 2>/dev/null | grep -c '"kind"'; }
+count() { timeout 8 noz req -k 1 -a "$PK2" -l 50 "$1" 2>/dev/null | grep -c '"kind"'; }
 
 # Admin (SEC1) follows SEC2 via a kind-3 contact list; SEC2 publishes notes.
-nak event --sec $SEC1 -k 3 -p "$PK2" -c "" "$SRC" >/dev/null 2>&1
+noz event --sec $SEC1 -k 3 -p "$PK2" -c "" "$SRC" >/dev/null 2>&1
 for i in $(seq 1 $N); do
-  nak event --sec $SEC2 -c "spider note $i" "$SRC" >/dev/null 2>&1
+  noz event --sec $SEC2 -c "spider note $i" "$SRC" >/dev/null 2>&1
 done
 sleep 1
 chk "source relay seeded with followed-author notes" "$N" "$(count "$SRC")"
@@ -51,7 +51,7 @@ done
 chk "spider synced followed-author notes via NIP-77" "$N" "$synced"
 
 # Live sync: a new note on the source should reach the spider.
-nak event --sec $SEC2 -c "spider live note" "$SRC" >/dev/null 2>&1
+noz event --sec $SEC2 -c "spider live note" "$SRC" >/dev/null 2>&1
 live=0
 start=$SECONDS
 until [ $((SECONDS - start)) -ge 30 ]; do


### PR DESCRIPTION
Replaces nak with **[noz](https://github.com/privkeyio/noz)** as the integration-test client across every suite and CI. This removes wisp's only Go-toolchain dependency and lets the suites carry the [NIP-77 sync fix](https://github.com/fiatjaf/nak/pull/141) nak declined to take.

**Two real relay bugs surfaced by the swap.** nak re-applies filters client-side, which silently masked these; noz trusts the relay, so they showed up as failing assertions:
1. The kind/pubkey fast-path set `skip_filter` without checking `since`/`until`, so a `-s`/`-u` bound on a kind/author query returned events outside the window.
2. An empty kind index could return the first stored event of a *different* kind (e.g. a kind-5 for `-k 20000`) because the first-entry path skipped the prefix check. Now scoped to the kind/pubkey indexes (the tag path scans separately).

Both are fixed in `store.zig` and covered by the existing protocol assertions (`since in future is empty`, `until in past is empty`, `ephemeral not stored`).

**Test/CI changes**
- All suites: `nak` → `noz`; COUNT reads noz's plain-number stdout; negentropy uses a single sync (no retry loop).
- CI builds noz from the pinned release tag `v0.2.0` instead of `go install`ing nak.

**Merge order (coordinated chain):** libnostr-z#131 → release `v0.3.5`; noz#3 re-pinned to `v0.3.5` → release `v0.2.0`; then this PR's CI goes green against `v0.2.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed query iterator prefix validation to prevent returning events from unintended index partitions
* Refined query filter optimization conditions for stricter temporal boundary handling

## Chores
* Updated build dependencies
* Updated internal testing infrastructure and tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->