### PR TITLE
Add configuration reference and refresh benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A fast, lightweight [nostr](https://github.com/nostr-protocol/nostr) relay writt
 
 ## Why Wisp?
 
-- **Fast**: 2x higher throughput than strfry, 10x lower latency
-- **Small**: Single 1.2MB binary, ~15MB RAM at idle
+- **Fast**: ~9x higher throughput than strfry, sub-millisecond p99 latency
+- **Small**: Single binary, ~11MB RAM at idle
 - **Simple**: One command to run your personal relay with your feed
 - **Spider Mode**: Automatically syncs events from people you follow
 
@@ -24,7 +24,7 @@ docker run -d -p 7777:7777 -v wisp-data:/data ghcr.io/privkeyio/wisp --spider-ad
 Download the [latest release](https://github.com/privkeyio/wisp/releases) or build from source:
 
 ```sh
-# 1. Install dependencies (requires Zig 0.15+)
+# 1. Install dependencies (requires Zig 0.16.0)
 sudo apt install -y liblmdb-dev libsecp256k1-dev libssl-dev
 
 # 2. Build
@@ -63,13 +63,13 @@ it there or at your reverse proxy/firewall if you don't want it public.
 
 ## Configuration
 
-Copy `wisp.toml.example` to `wisp.toml` and customize, or use environment variables with `WISP_` prefix:
+Copy `wisp.toml.example` to `wisp.toml` and customize, or use environment variables with the `WISP_` prefix:
 
 ```sh
 WISP_PORT=8080 ./zig-out/bin/wisp
 ```
 
-See `wisp.toml.example` for all options.
+Environment variables override the config file. See the **[Configuration reference](docs/configuration.md)** for every setting, its environment variable, default, and meaning.
 
 ## Deploy (wss://)
 
@@ -100,12 +100,15 @@ Your relay is now live at `wss://relay.yourdomain.com`.
 
 ## Benchmarks
 
-| Relay | Events/sec | p50 Latency | p99 Latency |
-|-------|-----------|-------------|-------------|
-| Wisp | 1,993 | 0.55ms | 0.82ms |
-| strfry | 872 | 4.28ms | 9.92ms |
+Peak write throughput, all relays at 100% delivery:
 
-*4 concurrent workers, 1k events. [Full results](https://github.com/privkeyio/nostr-bench/blob/main/reports/BENCHMARK_RESULTS.md)*
+| Relay | Events/sec | p99 Latency | Memory (RSS) |
+|-------|-----------:|------------:|-------------:|
+| **Wisp** | **25,600** | **0.28 ms** | 11 MB |
+| nostr-rs-relay | 5,400 | 5.9 ms | 20 MB |
+| strfry | 2,800 | 2.9 ms | 3 MB |
+
+*[nostr-bench](https://github.com/privkeyio/nostr-bench), 5,000 events x 4 workers at peak rate (`--rate 0`), native release builds on a 16-core Linux host, default configs with the event-rate limit raised. `RssAnon` sampled during the run. Wisp leads on throughput (~9x strfry, ~5x nostr-rs-relay) and p99 latency; strfry stays smallest in memory. Wisp defaults to LMDB `MDB_NOSYNC` (fast, less crash-durable) while strfry writes durably, so part of the write gap reflects that tradeoff.*
 
 ## Contributing
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,9 +1,18 @@
 # Benchmarks
 
-| Relay | Events/sec | p50 Latency | p99 Latency |
-|-------|-----------|-------------|-------------|
-| Wisp | 1,993 | 0.55ms | 0.82ms |
-| strfry | 872 | 4.28ms | 9.92ms |
+Peak write throughput, all relays at 100% delivery:
 
-*4 concurrent workers, 1k events.*
-[Full results](https://github.com/privkeyio/nostr-bench/blob/main/reports/BENCHMARK_RESULTS.md)
+| Relay | Events/sec | p99 Latency | Memory (RSS) |
+|-------|-----------:|------------:|-------------:|
+| **Wisp** | **25,600** | **0.28 ms** | 11 MB |
+| nostr-rs-relay | 5,400 | 5.9 ms | 20 MB |
+| strfry | 2,800 | 2.9 ms | 3 MB |
+
+Measured with [nostr-bench](https://github.com/privkeyio/nostr-bench): 5,000 events x 4
+workers at peak rate (`--rate 0`), native release builds on a 16-core Linux host, default
+configs with the event-rate limit raised. `RssAnon` sampled during the run; figures are
+representative of three stable iterations.
+
+Wisp leads on throughput (~9x strfry, ~5x nostr-rs-relay) and p99 latency; strfry stays
+smallest in memory. Wisp defaults to LMDB `MDB_NOSYNC` (fast, less crash-durable) while
+strfry writes durably, so part of the write-throughput gap reflects that tradeoff.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,35 +1,146 @@
 # Configuration
 
-Copy `wisp.toml.example` to `wisp.toml` and customize. A subset of options can also be
-overridden with a `WISP_`-prefixed environment variable (e.g. `WISP_PORT`,
-`WISP_STORAGE_PATH`, `WISP_MAX_CONNECTIONS`, `WISP_EVENTS_PER_MINUTE`). See `loadEnv` in
-[`src/config.zig`](https://github.com/privkeyio/wisp/blob/main/src/config.zig) for the
-authoritative list of supported variables:
+Wisp reads configuration from several sources, applied in order, each overriding the last:
+
+1. **Built-in defaults** (shown in the tables below).
+2. **A TOML file**, if you pass one: `wisp relay wisp.toml`.
+3. **Environment variables** (`WISP_*`), which override the file.
+4. **A few CLI flags** (`--spider-admin`, `--db`), which override everything for the settings they touch.
+
+So an environment variable always wins over the same setting in the TOML file. Copy
+[`wisp.toml.example`](https://github.com/privkeyio/wisp/blob/main/wisp.toml.example) to
+`wisp.toml` to start from an annotated template.
 
 ```sh
 WISP_PORT=8080 ./zig-out/bin/wisp
 ```
 
-See [`wisp.toml.example`](https://github.com/privkeyio/wisp/blob/main/wisp.toml.example) for
-the full, annotated list of options. The main sections:
+## Command line
 
-| Section | Purpose |
-|---------|---------|
-| `[server]` | Listen `host` and `port` (default `127.0.0.1:7777`). |
-| `[relay]` | Public relay metadata: `name`, `description`, `pubkey`, `contact`. |
-| `[storage]` | LMDB data `path` and map size. Point at `/dev/shm` (tmpfs) for ~2x lower latency, but note it is volatile (see warning below). |
-| `[limits]` | Connection, subscription, filter, message-size, and query limits. |
-| `[rate_limits]` | Per-relay event rate (`events_per_minute`). |
-| `[timeouts]` | Idle connection timeout. |
-| `[auth]` | Optional NIP-42 authentication for reads and/or writes. |
-| `[security]` | Per-IP connection limits, proxy trust, and IP allow/deny lists. |
-| `[spider]` | Sync events for followed pubkeys from external relays. |
-| `[negentropy]` | NIP-77 set-reconciliation sync. |
-| `[management]` | NIP-86 admin allowlist (`admin_pubkeys`). |
+```
+wisp [command] [config.toml]
+
+Commands:
+  relay [config]   Start the relay server (default if omitted)
+  import           Import events from stdin (JSONL)
+  export           Export all events to stdout (JSONL)
+  help             Show help
+
+Flags:
+  --spider-admin <npub|hex>   Enable spider mode and follow this pubkey's contacts
+  --db <path>                 Database path for import/export (default ./data)
+```
+
+The relay's storage path comes from `[storage] path` / `WISP_STORAGE_PATH`. `--db` applies
+to the `import` and `export` commands only. `--spider-admin` accepts an `npub` (decoded to
+hex), unlike the file/env spider settings which expect raw hex.
+
+## Settings
+
+Each setting lists its TOML key (under its `[section]`), its environment variable, type, and
+default. Settings with no environment variable are configurable only via the TOML file.
+
+### `[server]`
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `host` | `WISP_HOST` | string | `127.0.0.1` | Bind address. Use `0.0.0.0` only behind a reverse proxy. |
+| `port` | `WISP_PORT` | u16 | `7777` | Listen port. HTTP (NIP-11, NIP-86, `/metrics`) and WebSocket share this one port. |
+
+### `[relay]` (NIP-11 metadata)
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `name` | `WISP_RELAY_NAME` | string | `Wisp` | Relay name advertised in NIP-11. |
+| `description` | — | string | `A lightweight Nostr relay` | NIP-11 description. |
+| `pubkey` | — | hex | (unset) | Operator pubkey in NIP-11. |
+| `contact` | — | string | (unset) | Operator contact in NIP-11. |
+
+### `[storage]`
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `path` | `WISP_STORAGE_PATH` | string | `./data` | LMDB data directory. Point at `/dev/shm/wisp/data` (tmpfs) for lowest latency; data is then lost on reboot (see warning). |
+| `map_size_mb` | — | u32 | `10240` | LMDB maximum map size in MB. The hard upper bound on database size. |
 
 > **Warning:** `/dev/shm` is volatile tmpfs — all data is lost on reboot. Use it only for
-> benchmarks or disposable caches. For production, point `path` at persistent storage (a
-> real disk or persistent volume) and/or configure backups.
+> benchmarks or disposable caches. For production, point `path` at persistent storage and/or
+> configure backups.
+
+### `[limits]`
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `max_connections` | `WISP_MAX_CONNECTIONS` | u32 | `1000` | Maximum concurrent connections. |
+| `workers` | `WISP_WORKERS` | u16 | `0` | Epoll worker threads. `0` = auto (`min(CPU, 4)`). Set `1` on a personal or memory-constrained relay to shed per-worker buffers and threads. |
+| `max_subscriptions` | — | u32 | `20` | Maximum open REQ subscriptions per connection. |
+| `max_filters` | — | u32 | `10` | Maximum filters per REQ. |
+| `max_message_size` | — | u32 | `65536` | Maximum inbound WebSocket message size, in bytes. |
+| `max_event_tags` | — | u32 | `2000` | Maximum tags per event. |
+| `max_content_length` | — | u32 | `102400` | Maximum event `content` length, in bytes. |
+| `query_limit_default` | — | u32 | `500` | Events returned per REQ when the client sets no `limit`. |
+| `query_limit_max` | — | u32 | `5000` | Hard cap on events returned per REQ. |
+| `max_event_age` | — | i64 (seconds) | `94608000` | Reject events whose `created_at` is older than this (default 3 years). |
+| `max_future_seconds` | — | i64 (seconds) | `900` | Reject events dated more than this far in the future (default 15 minutes). |
+| `min_pow_difficulty` | `WISP_MIN_POW_DIFFICULTY` | u8 | `0` | Required NIP-13 proof-of-work leading-zero bits. `0` disables. |
+
+### `[rate_limits]`
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `events_per_minute` | `WISP_EVENTS_PER_MINUTE` | u32 | `120` | Per-IP event publish rate (token bucket). `0` disables. |
+| `queries_per_minute` | `WISP_QUERIES_PER_MINUTE` | u32 | `300` | Per-IP limit on expensive query messages (REQ / COUNT / NEG_OPEN). `0` disables. |
+
+### `[timeouts]`
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `idle_seconds` | `WISP_IDLE_SECONDS` | u32 | `300` | Close a connection after this many seconds with no activity. |
+
+### `[auth]` (NIP-42)
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `required` | `WISP_AUTH_REQUIRED` | bool | `false` | Require NIP-42 AUTH before any read or write. |
+| `to_write` | `WISP_AUTH_TO_WRITE` | bool | `false` | Require NIP-42 AUTH before publishing events. |
+| `relay_url` | `WISP_RELAY_URL` | string | (empty) | Canonical relay URL bound into the AUTH challenge. Set this to your public `wss://` URL when auth is enabled. |
+
+### `[security]`
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `trust_proxy` | `WISP_TRUST_PROXY` | bool | `false` | Honor `X-Forwarded-For` / `X-Real-IP` for the client IP. Enable only behind a reverse proxy whose backend port is not directly reachable, or clients can spoof their IP. |
+| `trusted_proxies` | `WISP_TRUSTED_PROXIES` | csv | (empty) | IPs/prefixes of proxies whose forwarded headers are trusted. Empty with `trust_proxy=true` trusts any peer. |
+| `max_connections_per_ip` | `WISP_MAX_CONNECTIONS_PER_IP` | u32 | `10` | Per-IP concurrent connection cap. |
+| `ip_whitelist` | `WISP_IP_WHITELIST` | csv | (empty) | If set, only these IPs/prefixes may connect. |
+| `ip_blacklist` | `WISP_IP_BLACKLIST` | csv | (empty) | These IPs/prefixes are refused. |
+
+IP list entries match exactly unless they end in `.` (IPv4 prefix) or `:` (IPv6 prefix), e.g.
+`10.0.0.` matches `10.0.0.0`–`10.0.0.255`. CIDR notation and `*` wildcards are not supported.
+
+### `[spider]`
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `enabled` | `WISP_SPIDER_ENABLED` | bool | `false` | Enable spider sync. |
+| `relays` | `WISP_SPIDER_RELAYS` | csv | (empty) | Upstream relay URLs to pull from. |
+| `admin` | `WISP_SPIDER_ADMIN` | hex | (empty) | Pubkey whose contact list seeds the follow set. |
+| `pubkeys` | `WISP_SPIDER_PUBKEYS` | csv | (empty) | Additional hex pubkeys to follow. |
+| `sync_interval` | `WISP_SPIDER_SYNC_INTERVAL` | u32 (seconds) | `300` | Seconds between sync passes. |
+
+### `[negentropy]` (NIP-77)
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `enabled` | `WISP_NEGENTROPY_ENABLED` | bool | `true` | Enable NIP-77 set reconciliation. |
+| `max_sync_events` | `WISP_NEGENTROPY_MAX_SYNC_EVENTS` | u32 | `1000000` | Maximum event IDs buffered per reconciliation session. |
+| `max_sessions` | `WISP_NEGENTROPY_MAX_SESSIONS` | u32 | `4` | Concurrent reconciliation sessions per connection. Each can buffer up to `max_sync_events` IDs, so keep this small. |
+
+### `[management]` (NIP-86)
+
+| TOML | Env | Type | Default | Description |
+|------|-----|------|---------|-------------|
+| `admin_pubkeys` | `WISP_ADMIN_PUBKEYS` | csv | (empty) | Hex pubkeys allowed to run NIP-86 relay-management commands (ban/allow pubkeys and IPs, etc.). |
 
 ## Spider mode
 
@@ -44,3 +155,10 @@ relays = "wss://relay.damus.io,wss://nos.lol,wss://relay.nostr.band"
 sync_interval = 300
 admin = ""  # your hex pubkey
 ```
+
+## Monitoring
+
+Operational metrics are served in Prometheus format at `GET /metrics` on the relay port:
+connection counts, events stored/rejected/broadcast, REQ totals, and rate-limit counters. The
+endpoint honors `ip_whitelist`/`ip_blacklist`, so restrict it there or at your reverse
+proxy/firewall if it should not be public.

--- a/wisp.toml.example
+++ b/wisp.toml.example
@@ -38,7 +38,7 @@ query_limit_max = 5000
 # min_pow_difficulty = 0
 
 [rate_limits]
-events_per_minute = 60
+events_per_minute = 120
 # Per-IP limit on expensive query messages (REQ/COUNT/NEG_OPEN). 0 disables.
 queries_per_minute = 300
 


### PR DESCRIPTION
Operator-facing docs for v1.

**CONFIGURATION.md** (new) — the full config reference. Every setting with its TOML key, environment variable, type, default, and meaning, grouped by section. Documents the precedence chain (defaults → TOML file → environment → CLI flags), the CLI commands/flags, and the `/metrics` endpoint. The `WISP_*` environment variables were previously documented nowhere, which matters for Docker/StartOS operators who don't use a TOML file.

**README** — points the Configuration section at CONFIGURATION.md; fixes the required Zig version (0.15+ → 0.16.0).

**Benchmarks** — replaced the stale two-row table with a freshly measured three-way peak-write run (wisp vs nostr-rs-relay vs strfry), all at 100% delivery on a 16-core host:

| Relay | Events/sec | p99 | RSS |
|---|--:|--:|--:|
| Wisp | 25,600 | 0.28 ms | 11 MB |
| nostr-rs-relay | 5,400 | 5.9 ms | 20 MB |
| strfry | 2,800 | 2.9 ms | 3 MB |

Stable across three iterations. Added the memory column (strfry wins there) and a note on wisp's `MDB_NOSYNC` durability tradeoff so the comparison is honest.

Also aligned `wisp.toml.example`'s `events_per_minute` to the real default (120).