### PR TITLE
Add configurable LMDB write durability (storage sync mode)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,10 +62,35 @@ default. Settings with no environment variable are configurable only via the TOM
 |------|-----|------|---------|-------------|
 | `path` | `WISP_STORAGE_PATH` | string | `./data` | LMDB data directory. Point at `/dev/shm/wisp/data` (tmpfs) for lowest latency; data is then lost on reboot (see warning). |
 | `map_size_mb` | — | u32 | `10240` | LMDB maximum map size in MB. The hard upper bound on database size. |
+| `sync` | `WISP_STORAGE_SYNC` | enum | `none` | Write durability: `none`, `meta`, or `full`. See [Durability](#durability). |
 
 > **Warning:** `/dev/shm` is volatile tmpfs — all data is lost on reboot. Use it only for
 > benchmarks or disposable caches. For production, point `path` at persistent storage and/or
 > configure backups.
+
+#### Durability
+
+`sync` controls how aggressively LMDB flushes to disk on each commit, trading throughput for
+crash safety:
+
+| Mode | Behavior | On crash / power loss |
+|------|----------|-----------------------|
+| `none` (default) | `MDB_NOSYNC` + `MDB_NOMETASYNC`: no flush on commit. Fastest. | Recent commits can be lost, and the database can be corrupted. |
+| `meta` | Flush data on every commit, defer only the metapage fsync. | The last transaction may roll back, but the database stays consistent. |
+| `full` | Fsync on every commit. Durable. | No acknowledged write is lost. |
+
+Indicative throughput on the same NVMe host (peak write, single session):
+
+| Mode | Events/sec | p99 |
+|------|-----------:|----:|
+| `none` | ~15,700 | 0.5 ms |
+| `meta` | ~2,300 | 3.1 ms |
+| `full` | ~1,300 | 8.9 ms |
+
+The durable modes are this much slower because Wisp commits one LMDB transaction per event,
+so `full` does one fsync per event with no batching. The default stays `none` to preserve
+current behavior; use `meta` for a good safety/throughput balance or `full` when no
+acknowledged write may ever be lost.
 
 ### `[limits]`
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -29,6 +29,10 @@ pub const Config = struct {
     max_future_seconds: i64,
     storage_path: []const u8,
     storage_map_size_mb: u32,
+    // LMDB durability: "none" (MDB_NOSYNC, fastest, can lose recent writes on
+    // crash), "meta" (flush data each commit, defer metapage fsync), or "full"
+    // (durable fsync each commit).
+    storage_sync: []const u8,
     idle_seconds: u32,
     events_per_minute: u32,
     // Per-IP limit on expensive query messages (REQ/COUNT/NEG_OPEN). 0 disables.
@@ -90,6 +94,7 @@ pub const Config = struct {
             .max_future_seconds = 900,
             .storage_path = "./data",
             .storage_map_size_mb = 10240,
+            .storage_sync = "none",
             .idle_seconds = 300,
             .events_per_minute = 120,
             .queries_per_minute = 300,
@@ -208,6 +213,8 @@ pub const Config = struct {
                 self.storage_path = try self.allocString(value);
             } else if (std.mem.eql(u8, key, "map_size_mb")) {
                 self.storage_map_size_mb = try std.fmt.parseInt(u32, value, 10);
+            } else if (std.mem.eql(u8, key, "sync")) {
+                self.storage_sync = try self.allocString(value);
             }
         } else if (std.mem.eql(u8, section, "timeouts")) {
             if (std.mem.eql(u8, key, "idle_seconds")) {
@@ -282,6 +289,7 @@ pub const Config = struct {
         }
         if (getenv("WISP_RELAY_NAME")) |v| self.name = v;
         if (getenv("WISP_STORAGE_PATH")) |v| self.storage_path = v;
+        if (getenv("WISP_STORAGE_SYNC")) |v| self.storage_sync = v;
         if (getenv("WISP_MAX_CONNECTIONS")) |v| {
             self.max_connections = std.fmt.parseInt(u32, v, 10) catch self.max_connections;
         }

--- a/src/lmdb.zig
+++ b/src/lmdb.zig
@@ -33,12 +33,23 @@ pub const Lmdb = struct {
         full,
 
         pub fn fromString(s: []const u8) ?SyncMode {
-            if (std.mem.eql(u8, s, "none")) return .none;
-            if (std.mem.eql(u8, s, "meta")) return .meta;
-            if (std.mem.eql(u8, s, "full")) return .full;
+            const trimmed = std.mem.trim(u8, s, &std.ascii.whitespace);
+            if (std.mem.eql(u8, trimmed, "none")) return .none;
+            if (std.mem.eql(u8, trimmed, "meta")) return .meta;
+            if (std.mem.eql(u8, trimmed, "full")) return .full;
             return null;
         }
     };
+
+    fn flagsFor(sync_mode: SyncMode) c_uint {
+        var flags: c_uint = c.MDB_NOSUBDIR | c.MDB_WRITEMAP | c.MDB_NORDAHEAD;
+        switch (sync_mode) {
+            .none => flags |= c.MDB_NOSYNC | c.MDB_NOMETASYNC,
+            .meta => flags |= c.MDB_NOMETASYNC,
+            .full => {},
+        }
+        return flags;
+    }
 
     pub fn init(allocator: std.mem.Allocator, path: []const u8, map_size_mb: u32, sync_mode: SyncMode) !Lmdb {
         var env: ?*c.MDB_env = null;
@@ -69,12 +80,7 @@ pub const Lmdb = struct {
         const path_z = try allocator.dupeZ(u8, path);
         defer allocator.free(path_z);
 
-        var flags: c_uint = c.MDB_NOSUBDIR | c.MDB_WRITEMAP | c.MDB_NORDAHEAD;
-        switch (sync_mode) {
-            .none => flags |= c.MDB_NOSYNC | c.MDB_NOMETASYNC,
-            .meta => flags |= c.MDB_NOMETASYNC,
-            .full => {},
-        }
+        const flags = flagsFor(sync_mode);
         const rc = c.mdb_env_open(env, path_z.ptr, flags, 0o600);
         if (rc != 0) {
             std.log.err("LMDB open failed: {}", .{rc});
@@ -255,3 +261,37 @@ pub const Entry = struct {
     key: []const u8,
     value: []const u8,
 };
+
+const testing = std.testing;
+
+test "SyncMode.fromString valid values" {
+    try testing.expectEqual(Lmdb.SyncMode.none, Lmdb.SyncMode.fromString("none").?);
+    try testing.expectEqual(Lmdb.SyncMode.meta, Lmdb.SyncMode.fromString("meta").?);
+    try testing.expectEqual(Lmdb.SyncMode.full, Lmdb.SyncMode.fromString("full").?);
+}
+
+test "SyncMode.fromString invalid values return null" {
+    try testing.expectEqual(@as(?Lmdb.SyncMode, null), Lmdb.SyncMode.fromString("ful"));
+    try testing.expectEqual(@as(?Lmdb.SyncMode, null), Lmdb.SyncMode.fromString(""));
+    try testing.expectEqual(@as(?Lmdb.SyncMode, null), Lmdb.SyncMode.fromString("FULL"));
+}
+
+test "SyncMode.fromString trims surrounding whitespace" {
+    try testing.expectEqual(Lmdb.SyncMode.full, Lmdb.SyncMode.fromString("full\n").?);
+    try testing.expectEqual(Lmdb.SyncMode.full, Lmdb.SyncMode.fromString(" full ").?);
+    try testing.expectEqual(Lmdb.SyncMode.meta, Lmdb.SyncMode.fromString("\tmeta\r\n").?);
+}
+
+test "flagsFor selects correct sync flags per mode" {
+    const none_flags = Lmdb.flagsFor(.none);
+    try testing.expect(none_flags & c.MDB_NOSYNC != 0);
+    try testing.expect(none_flags & c.MDB_NOMETASYNC != 0);
+
+    const meta_flags = Lmdb.flagsFor(.meta);
+    try testing.expect(meta_flags & c.MDB_NOSYNC == 0);
+    try testing.expect(meta_flags & c.MDB_NOMETASYNC != 0);
+
+    const full_flags = Lmdb.flagsFor(.full);
+    try testing.expect(full_flags & c.MDB_NOSYNC == 0);
+    try testing.expect(full_flags & c.MDB_NOMETASYNC == 0);
+}

--- a/src/lmdb.zig
+++ b/src/lmdb.zig
@@ -27,7 +27,20 @@ pub const Lmdb = struct {
     env: *c.MDB_env,
     allocator: std.mem.Allocator,
 
-    pub fn init(allocator: std.mem.Allocator, path: []const u8, map_size_mb: u32) !Lmdb {
+    pub const SyncMode = enum {
+        none,
+        meta,
+        full,
+
+        pub fn fromString(s: []const u8) ?SyncMode {
+            if (std.mem.eql(u8, s, "none")) return .none;
+            if (std.mem.eql(u8, s, "meta")) return .meta;
+            if (std.mem.eql(u8, s, "full")) return .full;
+            return null;
+        }
+    };
+
+    pub fn init(allocator: std.mem.Allocator, path: []const u8, map_size_mb: u32, sync_mode: SyncMode) !Lmdb {
         var env: ?*c.MDB_env = null;
 
         if (c.mdb_env_create(&env) != 0) {
@@ -56,7 +69,12 @@ pub const Lmdb = struct {
         const path_z = try allocator.dupeZ(u8, path);
         defer allocator.free(path_z);
 
-        const flags: c_uint = c.MDB_NOSUBDIR | c.MDB_NOSYNC | c.MDB_NOMETASYNC | c.MDB_WRITEMAP | c.MDB_NORDAHEAD;
+        var flags: c_uint = c.MDB_NOSUBDIR | c.MDB_WRITEMAP | c.MDB_NORDAHEAD;
+        switch (sync_mode) {
+            .none => flags |= c.MDB_NOSYNC | c.MDB_NOMETASYNC,
+            .meta => flags |= c.MDB_NOMETASYNC,
+            .full => {},
+        }
         const rc = c.mdb_env_open(env, path_z.ptr, flags, 0o600);
         if (rc != 0) {
             std.log.err("LMDB open failed: {}", .{rc});

--- a/src/main.zig
+++ b/src/main.zig
@@ -150,11 +150,16 @@ pub fn main(init: std.process.Init) !void {
     try nostr.init();
     defer nostr.cleanup();
 
-    std.log.info("Wisp v0.4.1 starting", .{});
-    std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
-    std.log.info("Storage: {s}", .{config.storage_path});
+    const sync_mode = Lmdb.SyncMode.fromString(config.storage_sync) orelse blk: {
+        std.log.warn("Unknown storage sync mode '{s}', using 'none'", .{config.storage_sync});
+        break :blk .none;
+    };
 
-    var lmdb = try Lmdb.init(allocator, config.storage_path, config.storage_map_size_mb);
+    std.log.info("Wisp v0.4.2 starting", .{});
+    std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
+    std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
+
+    var lmdb = try Lmdb.init(allocator, config.storage_path, config.storage_map_size_mb, sync_mode);
     defer lmdb.deinit();
 
     var store = try Store.init(allocator, &lmdb);
@@ -282,7 +287,7 @@ fn runImport(allocator: std.mem.Allocator, db_path: []const u8) !void {
     try nostr.init();
     defer nostr.cleanup();
 
-    var lmdb = try Lmdb.init(allocator, db_path, 10240);
+    var lmdb = try Lmdb.init(allocator, db_path, 10240, .none);
     defer lmdb.deinit();
 
     var store = try Store.init(allocator, &lmdb);
@@ -380,7 +385,7 @@ fn printStatus(file: std.Io.File, comptime fmt: []const u8, args: anytype) void 
 }
 
 fn runExport(allocator: std.mem.Allocator, db_path: []const u8) !void {
-    var lmdb = try Lmdb.init(allocator, db_path, 10240);
+    var lmdb = try Lmdb.init(allocator, db_path, 10240, .none);
     defer lmdb.deinit();
 
     var store = try Store.init(allocator, &lmdb);

--- a/src/main.zig
+++ b/src/main.zig
@@ -150,9 +150,9 @@ pub fn main(init: std.process.Init) !void {
     try nostr.init();
     defer nostr.cleanup();
 
-    const sync_mode = Lmdb.SyncMode.fromString(config.storage_sync) orelse blk: {
-        std.log.warn("Unknown storage sync mode '{s}', using 'none'", .{config.storage_sync});
-        break :blk .none;
+    const sync_mode = Lmdb.SyncMode.fromString(config.storage_sync) orelse {
+        std.log.err("Invalid storage sync mode '{s}', valid options are: none, meta, full", .{config.storage_sync});
+        return error.InvalidSyncMode;
     };
 
     std.log.info("Wisp v0.4.2 starting", .{});

--- a/src/nip86.zig
+++ b/src/nip86.zig
@@ -369,7 +369,7 @@ test "nip86 dispatch routing, param guards, and store round-trip" {
         cwd.deleteFile(io, db_path ++ "-lock") catch {};
     }
 
-    var lmdb = try Lmdb.init(testing.allocator, db_path, 10);
+    var lmdb = try Lmdb.init(testing.allocator, db_path, 10, .none);
     defer lmdb.deinit();
     var mgmt = try ManagementStore.init(testing.allocator, &lmdb);
 

--- a/wisp.toml.example
+++ b/wisp.toml.example
@@ -15,6 +15,10 @@ description = "A lightweight Nostr relay"
 [storage]
 path = "./data"
 # map_size_mb = 10240
+# Write durability: "none" (fastest, can lose recent writes on crash), "meta"
+# (flush data each commit, defer metapage fsync), or "full" (durable fsync each
+# commit). Use "meta" or "full" for production data you cannot lose.
+# sync = "none"
 
 # Performance tip: For maximum throughput, use RAM-backed storage (tmpfs):
 #   path = "/dev/shm/wisp/data"


### PR DESCRIPTION
Closes #89.

Wisp opens LMDB with `MDB_NOSYNC | MDB_NOMETASYNC`, so writes are fast but a crash or power loss can lose (and even corrupt) recently acknowledged events. strfry and nostr-rs-relay write durably by default; this lets a wisp operator pick where on that curve to sit.

## Change

New `[storage] sync` setting (env `WISP_STORAGE_SYNC`), with three modes:

| Mode | LMDB flags | On crash |
|------|-----------|----------|
| `none` (default) | `NOSYNC` + `NOMETASYNC` | recent commits can be lost / DB corrupted |
| `meta` | `NOMETASYNC` only | last txn may roll back, DB stays consistent |
| `full` | (neither) | no acknowledged write lost |

`MDB_WRITEMAP | MDB_NORDAHEAD | MDB_NOSUBDIR` are unchanged. Default stays `none`, so existing deployments are byte-identical. An unknown value logs a warning and falls back to `none`. The chosen mode is logged at startup. import/export use `none` (they full-sync on close anyway).

## Reference

Mirrors strfry: durable = no `NOSYNC`/`NOMETASYNC` (strfry's `dbFlags` start at 0 and only add `NORDAHEAD`).

## Tradeoff (measured, same NVMe host, peak write)

| Mode | Events/sec | p99 |
|------|-----------:|----:|
| `none` | ~15,700 | 0.5 ms |
| `meta` | ~2,300 | 3.1 ms |
| `full` | ~1,300 | 8.9 ms |

The durable modes are slow because Wisp commits one LMDB transaction per event, so `full` does one fsync per event. strfry stays durable and fast (~2,800 ev/s) by batching up to 1,000 events into a single committed transaction via a dedicated writer thread, amortizing the fsync. Adding that group-commit path to Wisp is tracked in #92.

## Default

Stays `none` in this PR. A durable default only makes sense once group-commit batching (#92) makes durable throughput competitive; flipping the default is deferred until then.

## Verification

- All three modes store + retrieve; bogus value falls back to `none`.
- Protocol suite 36/36 in default mode (no regression).
- `zig build` + `zig build test` clean.

Also fixed the stale `v0.4.1` startup log (now `v0.4.2`).
