### PR TITLE
Add group-commit writer for durable sync modes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,18 +79,14 @@ crash safety:
 | `meta` | Flush data on every commit, defer only the metapage fsync. | The last transaction may roll back, but the database stays consistent. |
 | `full` | Fsync on every commit. Durable. | No acknowledged write is lost. |
 
-Indicative throughput on the same NVMe host (peak write, single session):
+In the durable modes (`meta`/`full`) writes go through a group-commit writer
+thread: events that arrive close together are committed in one transaction, so a
+batch pays a single fsync rather than one per event. Throughput therefore scales
+with how many clients publish concurrently. The default `none` mode keeps the
+faster synchronous write path, since there is no fsync to amortize.
 
-| Mode | Events/sec | p99 |
-|------|-----------:|----:|
-| `none` | ~15,700 | 0.5 ms |
-| `meta` | ~2,300 | 3.1 ms |
-| `full` | ~1,300 | 8.9 ms |
-
-The durable modes are this much slower because Wisp commits one LMDB transaction per event,
-so `full` does one fsync per event with no batching. The default stays `none` to preserve
-current behavior; use `meta` for a good safety/throughput balance or `full` when no
-acknowledged write may ever be lost.
+The default stays `none` to preserve current behavior; use `meta` for a good
+safety/throughput balance, or `full` when no acknowledged write may ever be lost.
 
 ### `[limits]`
 

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -9,6 +9,7 @@ const NegSession = connection.NegSession;
 const nostr = @import("nostr.zig");
 const rate_limiter = @import("rate_limiter.zig");
 const ManagementStore = @import("management_store.zig").ManagementStore;
+const Writer = @import("writer.zig").Writer;
 const metrics = @import("relay_metrics.zig");
 
 fn isKindOnlyQuery(f: *const nostr.Filter) bool {
@@ -155,6 +156,10 @@ pub const Handler = struct {
     query_limiter: *rate_limiter.EventRateLimiter,
     shutdown: *std.atomic.Value(bool),
     mgmt_store: *ManagementStore,
+    // Group-commit writer, present only for durable sync modes (meta/full). When
+    // null (the default, non-durable `none` mode) events are stored synchronously
+    // on the worker thread, which is faster when there is no fsync to amortize.
+    writer: ?*Writer,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -166,6 +171,7 @@ pub const Handler = struct {
         query_limiter: *rate_limiter.EventRateLimiter,
         shutdown: *std.atomic.Value(bool),
         mgmt_store: *ManagementStore,
+        writer: ?*Writer,
     ) Handler {
         return .{
             .allocator = allocator,
@@ -177,6 +183,7 @@ pub const Handler = struct {
             .query_limiter = query_limiter,
             .shutdown = shutdown,
             .mgmt_store = mgmt_store,
+            .writer = writer,
         };
     }
 
@@ -345,6 +352,16 @@ pub const Handler = struct {
             };
         };
 
+        // Durable modes: hand off to the group-commit writer, which stores the
+        // event in a batched transaction and sends OK + broadcasts only after the
+        // commit, so an acknowledged write is on disk. Validation stays synchronous.
+        if (self.writer) |writer| {
+            if (!writer.submit(.event, conn.id, json)) {
+                self.sendOk(conn, id, false, "error: relay overloaded");
+            }
+            return;
+        }
+
         const result = self.store.store(&event, json) catch {
             self.sendOk(conn, id, false, "error: storage failed");
             return;
@@ -358,7 +375,6 @@ pub const Handler = struct {
         }
 
         self.sendOk(conn, id, true, "");
-
         self.broadcaster.broadcast(&event);
     }
 
@@ -372,15 +388,29 @@ pub const Handler = struct {
         };
         defer self.allocator.free(ids_to_delete);
 
+        const json = if (event.raw_json.len > 0)
+            event.raw_json
+        else blk: {
+            var json_buf: [65536]u8 = undefined;
+            break :blk event.serialize(&json_buf) catch {
+                self.sendOk(conn, id, false, "error: serialization failed");
+                return;
+            };
+        };
+
+        // Durable modes: the writer applies the deletions and stores the deletion
+        // event in the same batched, ordered transaction as regular events, which
+        // preserves same-connection publish/delete ordering.
+        if (self.writer) |writer| {
+            if (!writer.submit(.deletion, conn.id, json)) {
+                self.sendOk(conn, id, false, "error: relay overloaded");
+            }
+            return;
+        }
+
         for (ids_to_delete) |target_id| {
             _ = self.store.delete(&target_id, pubkey) catch {};
         }
-
-        var json_buf: [65536]u8 = undefined;
-        const json = event.serialize(&json_buf) catch {
-            self.sendOk(conn, id, false, "error: serialization failed");
-            return;
-        };
 
         const stored = if (self.store.store(event, json)) |r| r.stored else |_| false;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -18,6 +18,7 @@ const nostr = @import("nostr.zig");
 const rate_limiter = @import("rate_limiter.zig");
 const ManagementStore = @import("management_store.zig").ManagementStore;
 const Nip86Handler = @import("nip86.zig").Nip86Handler;
+const Writer = @import("writer.zig").Writer;
 
 var g_shutdown: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
@@ -182,7 +183,17 @@ pub fn main(init: std.process.Init) !void {
     var query_limiter = rate_limiter.EventRateLimiter.init(allocator, config.queries_per_minute);
     defer query_limiter.deinit();
 
-    var handler = Handler.init(allocator, &config, &store, &subs, &broadcaster, &event_limiter, &query_limiter, &g_shutdown, &mgmt_store);
+    // The group-commit writer exists only for durable sync modes, where batching
+    // amortizes the fsync. In the default non-durable mode events are stored
+    // synchronously, which is faster with nothing to flush.
+    var writer = Writer.init(allocator, &store, &broadcaster, &subs);
+    const writer_ptr: ?*Writer = if (sync_mode == .none) null else blk: {
+        try writer.start();
+        break :blk &writer;
+    };
+    defer if (writer_ptr) |w| w.deinit();
+
+    var handler = Handler.init(allocator, &config, &store, &subs, &broadcaster, &event_limiter, &query_limiter, &g_shutdown, &mgmt_store, writer_ptr);
 
     var server: Server = undefined;
     try server.init(allocator, init.io, &config, &handler, &subs, &g_shutdown, &nip86_handler);

--- a/src/store.zig
+++ b/src/store.zig
@@ -61,50 +61,47 @@ pub const Store = struct {
     }
 
     pub fn store(self: *Store, event: *const nostr.Event, json: []const u8) !StoreResult {
+        var txn = try self.lmdb.beginTxn(false);
+        errdefer txn.abort();
+        const result = try self.storeInTxn(&txn, event, json);
+        try txn.commit();
+        if (result.stored) self.query_cache.invalidate();
+        return result;
+    }
+
+    // Store an event within a caller-provided write transaction. Never aborts the
+    // txn: every rejection is decided before any write, so a rejected event leaves
+    // the shared (batched) transaction untouched. The caller commits and, when any
+    // event in the batch was stored, invalidates the query cache.
+    pub fn storeInTxn(self: *Store, txn: *Txn, event: *const nostr.Event, json: []const u8) !StoreResult {
         const kind_type = nostr.kindType(event.kind());
 
         if (kind_type == .ephemeral) {
             return .{ .stored = false, .message = "ephemeral: not stored" };
         }
 
-        var txn = try self.lmdb.beginTxn(false);
-        errdefer txn.abort();
-
         const id = event.id();
 
         if (try txn.get(self.deleted, id) != null) {
-            txn.abort();
             return .{ .stored = false, .message = "deleted: event was deleted" };
         }
 
-        var replaced_id: ?[32]u8 = null;
+        if (try txn.get(self.events, id) != null) {
+            return .{ .stored = false, .message = "duplicate: already have this event" };
+        }
 
+        var replaced_id: ?[32]u8 = null;
         if (kind_type == .replaceable or kind_type == .addressable) {
-            const result = try self.handleReplaceable(&txn, event, kind_type);
+            const result = try self.handleReplaceable(txn, event, kind_type);
             switch (result) {
-                .rejected => {
-                    txn.abort();
-                    return .{ .stored = false, .message = "replaced: have newer event" };
-                },
-                .replaced => |rid| {
-                    replaced_id = rid;
-                },
+                .rejected => return .{ .stored = false, .message = "replaced: have newer event" },
+                .replaced => |rid| replaced_id = rid,
                 .new_entry => {},
             }
         }
 
-        txn.putNoOverwrite(self.events, id, json) catch |err| {
-            if (err == error.KeyExists) {
-                txn.abort();
-                return .{ .stored = false, .message = "duplicate: already have this event" };
-            }
-            return err;
-        };
-
-        try self.indexEvent(&txn, event);
-        try txn.commit();
-
-        self.query_cache.invalidate();
+        try txn.put(self.events, id, json);
+        try self.indexEvent(txn, event);
 
         return .{ .stored = true, .replaced_id = replaced_id };
     }
@@ -250,25 +247,27 @@ pub const Store = struct {
     pub fn delete(self: *Store, event_id: *const [32]u8, requester_pubkey: *const [32]u8) !bool {
         var txn = try self.lmdb.beginTxn(false);
         errdefer txn.abort();
+        const ok = try self.deleteInTxn(&txn, event_id, requester_pubkey);
+        try txn.commit();
+        if (ok) self.query_cache.invalidate();
+        return ok;
+    }
 
-        const json = try txn.get(self.events, event_id) orelse {
-            txn.abort();
-            return false;
-        };
+    // Delete within a caller-provided write transaction (no abort, no commit). The
+    // requester must own the event. Returns false if the event is absent or not
+    // owned, leaving the shared transaction untouched.
+    pub fn deleteInTxn(self: *Store, txn: *Txn, event_id: *const [32]u8, requester_pubkey: *const [32]u8) !bool {
+        const json = try txn.get(self.events, event_id) orelse return false;
 
         var event = try nostr.Event.parse(json);
         defer event.deinit();
 
-        if (!std.mem.eql(u8, event.pubkey(), requester_pubkey)) {
-            txn.abort();
-            return false;
-        }
+        if (!std.mem.eql(u8, event.pubkey(), requester_pubkey)) return false;
 
-        try self.deleteEventInternal(&txn, &event);
+        try self.deleteEventInternal(txn, &event);
         const now = nostr.io.timestamp();
         const now_bytes = std.mem.asBytes(&now);
         try txn.put(self.deleted, event_id, now_bytes);
-        try txn.commit();
         return true;
     }
 

--- a/src/subscriptions.zig
+++ b/src/subscriptions.zig
@@ -78,6 +78,21 @@ pub const Subscriptions = struct {
         return true;
     }
 
+    // Write a message to one connection by id, bumping its write_guard under the
+    // registry lock so the connection cannot be freed mid-write. Used by the
+    // writer thread to deliver OK replies after a batch commits.
+    pub fn sendTo(self: *Subscriptions, conn_id: u64, data: []const u8) void {
+        const io = nostr.io.io();
+        self.rwlock.lockSharedUncancelable(io);
+        const conn = self.connections.get(conn_id);
+        if (conn) |c| _ = c.write_guard.fetchAdd(1, .acquire);
+        self.rwlock.unlockShared(io);
+
+        const c = conn orelse return;
+        defer _ = c.write_guard.fetchSub(1, .release);
+        c.write(data) catch {};
+    }
+
     pub fn connectionCount(self: *Subscriptions) usize {
         const io = nostr.io.io();
         self.rwlock.lockSharedUncancelable(io);

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -12,6 +12,9 @@ const metrics = @import("relay_metrics.zig");
 // happen only after the batch commits, so an acknowledged write is on disk.
 const MAX_BATCH = 1000;
 const MAX_QUEUE = 200_000;
+// Cap total bytes of queued JSON so a flood (or a slow fsync in a durable sync
+// mode) can't grow the queue into an OOM regardless of max_message_size.
+const MAX_QUEUE_BYTES = 256 * 1024 * 1024;
 
 const JobKind = enum { event, deletion };
 
@@ -38,6 +41,7 @@ pub const Writer = struct {
     mutex: std.Io.Mutex = .init,
     cond: std.Io.Condition = .init,
     queue: std.ArrayListUnmanaged(Job) = .empty,
+    queued_bytes: usize = 0,
     shutdown: std.atomic.Value(bool) = .init(false),
     thread: ?std.Thread = null,
 
@@ -60,8 +64,14 @@ pub const Writer = struct {
     }
 
     pub fn deinit(self: *Writer) void {
+        const io = nostr.io.io();
+        // Set shutdown under the mutex so it can't slip between the writer
+        // thread's predicate check and its wait, which would be a lost wakeup
+        // and deadlock the join below.
+        self.mutex.lockUncancelable(io);
         self.shutdown.store(true, .release);
-        self.cond.broadcast(nostr.io.io());
+        self.mutex.unlock(io);
+        self.cond.broadcast(io);
         if (self.thread) |t| t.join();
         for (self.queue.items) |job| self.allocator.free(job.json);
         self.queue.deinit(self.allocator);
@@ -72,7 +82,7 @@ pub const Writer = struct {
         const io = nostr.io.io();
         const copy = self.allocator.dupe(u8, json) catch return false;
         self.mutex.lockUncancelable(io);
-        if (self.queue.items.len >= MAX_QUEUE) {
+        if (self.queue.items.len >= MAX_QUEUE or self.queued_bytes + copy.len > MAX_QUEUE_BYTES) {
             self.mutex.unlock(io);
             self.allocator.free(copy);
             return false;
@@ -82,6 +92,7 @@ pub const Writer = struct {
             self.allocator.free(copy);
             return false;
         };
+        self.queued_bytes += copy.len;
         self.mutex.unlock(io);
         self.cond.signal(io);
         return true;
@@ -103,6 +114,7 @@ pub const Writer = struct {
             // load batches are small but commits are cheap anyway.
             var pending = self.queue;
             self.queue = .empty;
+            self.queued_bytes = 0;
             self.mutex.unlock(io);
 
             var i: usize = 0;
@@ -134,7 +146,10 @@ pub const Writer = struct {
         var fatal = false;
 
         for (jobs) |job| {
-            var event = nostr.Event.parse(job.json) catch continue;
+            var event = nostr.Event.parse(job.json) catch {
+                std.log.warn("writer: dropping job, failed to re-parse queued event", .{});
+                continue;
+            };
             const p = self.applyJob(&txn, job, &event) catch {
                 event.deinit();
                 fatal = true;
@@ -163,7 +178,7 @@ pub const Writer = struct {
         if (stored_any) self.store.query_cache.invalidate();
 
         for (processed[0..n]) |*p| {
-            if (p.success) metrics.eventStored() else metrics.eventRejected();
+            if (p.broadcast) metrics.eventStored() else if (!p.success) metrics.eventRejected();
             self.reply(p.conn_id, p.event.id(), p.success, p.message);
             if (p.broadcast) self.broadcaster.broadcast(&p.event);
             p.event.deinit();
@@ -178,10 +193,9 @@ pub const Writer = struct {
         if (job.kind == .deletion) {
             const ids = nostr.getDeletionIds(self.allocator, event) catch null;
             defer if (ids) |slice| self.allocator.free(slice);
-            if (ids) |slice| {
-                for (slice) |target| {
-                    _ = try self.store.deleteInTxn(txn, &target, event.pubkey());
-                }
+            const slice = ids orelse return .{ .conn_id = job.conn_id, .event = event.*, .success = false, .message = "error: failed to parse deletion", .broadcast = false };
+            for (slice) |target| {
+                _ = try self.store.deleteInTxn(txn, &target, event.pubkey());
             }
             _ = try self.store.storeInTxn(txn, event, job.json);
             return .{ .conn_id = job.conn_id, .event = event.*, .success = true, .message = "", .broadcast = true };

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -1,0 +1,216 @@
+const std = @import("std");
+const nostr = @import("nostr.zig");
+const Store = @import("store.zig").Store;
+const Broadcaster = @import("broadcaster.zig").Broadcaster;
+const Subscriptions = @import("subscriptions.zig").Subscriptions;
+const metrics = @import("relay_metrics.zig");
+
+// Group-commit writer. EVENT and deletion jobs are queued by the worker threads
+// (after synchronous validation) and drained by a single writer thread that
+// batches up to MAX_BATCH jobs into one LMDB transaction, so a durable sync mode
+// pays one fsync per batch instead of one per event. OK replies and broadcasts
+// happen only after the batch commits, so an acknowledged write is on disk.
+const MAX_BATCH = 1000;
+const MAX_QUEUE = 200_000;
+
+const JobKind = enum { event, deletion };
+
+const Job = struct {
+    kind: JobKind,
+    conn_id: u64,
+    json: []u8,
+};
+
+const Processed = struct {
+    conn_id: u64,
+    event: nostr.Event,
+    success: bool,
+    message: []const u8,
+    broadcast: bool,
+};
+
+pub const Writer = struct {
+    allocator: std.mem.Allocator,
+    store: *Store,
+    broadcaster: *Broadcaster,
+    subs: *Subscriptions,
+
+    mutex: std.Io.Mutex = .init,
+    cond: std.Io.Condition = .init,
+    queue: std.ArrayListUnmanaged(Job) = .empty,
+    shutdown: std.atomic.Value(bool) = .init(false),
+    thread: ?std.Thread = null,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        store: *Store,
+        broadcaster: *Broadcaster,
+        subs: *Subscriptions,
+    ) Writer {
+        return .{
+            .allocator = allocator,
+            .store = store,
+            .broadcaster = broadcaster,
+            .subs = subs,
+        };
+    }
+
+    pub fn start(self: *Writer) !void {
+        self.thread = try std.Thread.spawn(.{}, run, .{self});
+    }
+
+    pub fn deinit(self: *Writer) void {
+        self.shutdown.store(true, .release);
+        self.cond.broadcast(nostr.io.io());
+        if (self.thread) |t| t.join();
+        for (self.queue.items) |job| self.allocator.free(job.json);
+        self.queue.deinit(self.allocator);
+    }
+
+    // Queue a job. Returns false when overloaded (caller replies error) or on OOM.
+    pub fn submit(self: *Writer, kind: JobKind, conn_id: u64, json: []const u8) bool {
+        const io = nostr.io.io();
+        const copy = self.allocator.dupe(u8, json) catch return false;
+        self.mutex.lockUncancelable(io);
+        if (self.queue.items.len >= MAX_QUEUE) {
+            self.mutex.unlock(io);
+            self.allocator.free(copy);
+            return false;
+        }
+        self.queue.append(self.allocator, .{ .kind = kind, .conn_id = conn_id, .json = copy }) catch {
+            self.mutex.unlock(io);
+            self.allocator.free(copy);
+            return false;
+        };
+        self.mutex.unlock(io);
+        self.cond.signal(io);
+        return true;
+    }
+
+    fn run(self: *Writer) void {
+        const io = nostr.io.io();
+        while (true) {
+            self.mutex.lockUncancelable(io);
+            while (self.queue.items.len == 0 and !self.shutdown.load(.acquire)) {
+                self.cond.waitUncancelable(io, &self.mutex);
+            }
+            if (self.queue.items.len == 0) {
+                self.mutex.unlock(io);
+                break; // queue drained and shutdown requested
+            }
+            // Take everything queued so far. Under load many events accumulate
+            // between wakeups and commit together, amortizing the fsync; at low
+            // load batches are small but commits are cheap anyway.
+            var pending = self.queue;
+            self.queue = .empty;
+            self.mutex.unlock(io);
+
+            var i: usize = 0;
+            while (i < pending.items.len) {
+                const end = @min(i + MAX_BATCH, pending.items.len);
+                self.processBatch(pending.items[i..end]);
+                i = end;
+            }
+            pending.deinit(self.allocator);
+        }
+    }
+
+    fn processBatch(self: *Writer, jobs: []Job) void {
+        const processed = self.allocator.alloc(Processed, jobs.len) catch {
+            self.replyErrorAll(jobs);
+            self.freeJobs(jobs);
+            return;
+        };
+        defer self.allocator.free(processed);
+
+        var txn = self.store.lmdb.beginTxn(false) catch {
+            self.replyErrorAll(jobs);
+            self.freeJobs(jobs);
+            return;
+        };
+
+        var n: usize = 0;
+        var stored_any = false;
+        var fatal = false;
+
+        for (jobs) |job| {
+            var event = nostr.Event.parse(job.json) catch continue;
+            const p = self.applyJob(&txn, job, &event) catch {
+                event.deinit();
+                fatal = true;
+                break;
+            };
+            if (p.success and p.broadcast) stored_any = true;
+            processed[n] = p;
+            n += 1;
+        }
+
+        if (fatal) {
+            txn.abort();
+            for (processed[0..n]) |*p| p.event.deinit();
+            self.replyErrorAll(jobs);
+            self.freeJobs(jobs);
+            return;
+        }
+
+        txn.commit() catch {
+            for (processed[0..n]) |*p| p.event.deinit();
+            self.replyErrorAll(jobs);
+            self.freeJobs(jobs);
+            return;
+        };
+
+        if (stored_any) self.store.query_cache.invalidate();
+
+        for (processed[0..n]) |*p| {
+            if (p.success) metrics.eventStored() else metrics.eventRejected();
+            self.reply(p.conn_id, p.event.id(), p.success, p.message);
+            if (p.broadcast) self.broadcaster.broadcast(&p.event);
+            p.event.deinit();
+        }
+
+        self.freeJobs(jobs);
+    }
+
+    // Apply one job within the shared txn and return how to reply. Returns an
+    // error only on a fatal txn failure (which aborts the whole batch).
+    fn applyJob(self: *Writer, txn: anytype, job: Job, event: *nostr.Event) !Processed {
+        if (job.kind == .deletion) {
+            const ids = nostr.getDeletionIds(self.allocator, event) catch null;
+            defer if (ids) |slice| self.allocator.free(slice);
+            if (ids) |slice| {
+                for (slice) |target| {
+                    _ = try self.store.deleteInTxn(txn, &target, event.pubkey());
+                }
+            }
+            _ = try self.store.storeInTxn(txn, event, job.json);
+            return .{ .conn_id = job.conn_id, .event = event.*, .success = true, .message = "", .broadcast = true };
+        }
+
+        const result = try self.store.storeInTxn(txn, event, job.json);
+        if (result.stored) {
+            return .{ .conn_id = job.conn_id, .event = event.*, .success = true, .message = "", .broadcast = true };
+        }
+        const dup = std.mem.startsWith(u8, result.message, "duplicate");
+        return .{ .conn_id = job.conn_id, .event = event.*, .success = dup, .message = result.message, .broadcast = false };
+    }
+
+    fn reply(self: *Writer, conn_id: u64, event_id: *const [32]u8, success: bool, message: []const u8) void {
+        var buf: [512]u8 = undefined;
+        const msg = nostr.RelayMsg.ok(event_id, success, message, &buf) catch return;
+        self.subs.sendTo(conn_id, msg);
+    }
+
+    fn replyErrorAll(self: *Writer, jobs: []Job) void {
+        for (jobs) |job| {
+            metrics.eventRejected();
+            var event = nostr.Event.parse(job.json) catch continue;
+            defer event.deinit();
+            self.reply(job.conn_id, event.id(), false, "error: storage failed");
+        }
+    }
+
+    fn freeJobs(self: *Writer, jobs: []Job) void {
+        for (jobs) |job| self.allocator.free(job.json);
+    }
+};


### PR DESCRIPTION
Closes #92.

Adds a strfry-style group-commit writer so the durable sync modes (`meta`/`full`, from #91) amortize the fsync across a batch instead of paying one per event.

## Design

In `meta`/`full` mode, a single writer thread drains a queue of EVENT and deletion jobs and commits each batch (up to 1000 jobs) in one LMDB transaction. `OK` and broadcast are sent only after the batch commits, so an acknowledged write is on disk. Validation stays synchronous on the worker threads; only store + OK + broadcast move to the writer.

The default non-durable `none` mode keeps the synchronous write path: with no fsync to amortize the async hop is pure overhead, and benchmarks confirmed routing `none` through the writer regressed it. So the writer is created only when `sync != none`.

Mirrors strfry's `WriterPipeline` (batch up to 1000 per commit, durable LMDB), adapted to wisp's epoll worker pool: events arrive concurrently from many workers and coalesce naturally, so there is no debounce timer (a timer would stall synchronous request/response clients).

## Correctness

- **Same-connection ordering:** deletions go through the same FIFO queue as events, so a `publish E` then `delete E` from one connection is applied in order within the batch transaction.
- **Abort-free batching:** `storeInTxn`/`deleteInTxn` decide every rejection (ephemeral, deleted, duplicate, replaced) before any write, so a rejected event never dirties the shared transaction; one bad job cannot poison the batch.
- **Async OK safety:** the writer delivers OK via `Subscriptions.sendTo`, which bumps the connection's `write_guard` under the registry lock (the existing broadcast invariant); `close()` drains the guard before freeing, so there is no use-after-free.
- **Shutdown:** the writer drains and commits its queue before the store/LMDB close (teardown order), so queued acknowledged writes are not lost.

## Throughput

Durable throughput now scales with publisher concurrency (batches grow with load). On this host `full` went from ~1,140 ev/s at 4 concurrent publishers to ~2,710 at 16; `meta` reached ~3,600 at high concurrency, all at 100% delivery. `none` is unchanged (synchronous path). Absolute numbers are rough (shared host); the trend is the point: batching lifts durable throughput as concurrency rises, which is the regime a real relay runs in.

## Verification

- Protocol suite 36/36 in both `full` (writer path: events, deletions, replaceables, expiration) and `none` (synchronous path).
- restrict (auth/protected/pow), management (NIP-86), negentropy, spider, concurrency suites all pass.
- 50/50 events acked and stored in `full` mode (every write durable).
- `zig build` + `zig build test` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented group-commit batching for durable sync modes, improving write throughput when handling concurrent publishers.

* **Documentation**
  * Updated durability documentation to explain group-commit behavior and throughput improvements in durable sync modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->