### PR TITLE
Default storage sync to meta for crash safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build noz (nostr test client)
         env:
-          NOZ_VERSION: v0.2.0
+          NOZ_VERSION: v0.2.1
         run: |
           git clone --depth 1 --branch "$NOZ_VERSION" https://github.com/privkeyio/noz "$RUNNER_TEMP/noz"
           (cd "$RUNNER_TEMP/noz" && zig build -Doptimize=ReleaseFast)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Default storage `sync` mode is now `meta` (durable, never corrupts) instead of `none`; use `sync = none` for maximum throughput on disposable data
-- Updated libnostr-z to v0.3.3
+- Updated libnostr-z to v0.3.6
 - Updated libnostr-z to v0.1.6
 
 ### Fixed
 
+- Fixed lost WebSocket read events under load that could leak connections (CLOSE_WAIT) and hang clients, e.g. an authed publish whose NIP-42 challenge arrived in the same packet as the upgrade response (http.zig and libnostr-z websocket fixes)
 - No longer send `CLOSED` in reply to a client `CLOSE` (NIP-01)
 - Fixed config file argument parsing and inline comment handling
 - Fixed spider connection handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Default storage `sync` mode is now `meta` (durable, never corrupts) instead of `none`; use `sync = none` for maximum throughput on disposable data
 - Updated libnostr-z to v0.3.3
 - Updated libnostr-z to v0.1.6
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Peak write throughput, all relays at 100% delivery:
 | nostr-rs-relay | 5,400 | 5.9 ms | 20 MB |
 | strfry | 2,800 | 2.9 ms | 3 MB |
 
-*[nostr-bench](https://github.com/privkeyio/nostr-bench), 5,000 events x 4 workers at peak rate (`--rate 0`), native release builds on a 16-core Linux host, default configs with the event-rate limit raised. `RssAnon` sampled during the run. Wisp leads on throughput (~9x strfry, ~5x nostr-rs-relay) and p99 latency; strfry stays smallest in memory. Wisp defaults to LMDB `MDB_NOSYNC` (fast, less crash-durable) while strfry writes durably, so part of the write gap reflects that tradeoff.*
+*[nostr-bench](https://github.com/privkeyio/nostr-bench), 5,000 events x 4 workers at peak rate (`--rate 0`), native release builds on a 16-core Linux host, with the event-rate limit raised. `RssAnon` sampled during the run. These are peak figures with Wisp in `sync = none` (non-durable); Wisp's default is `sync = meta` (durable, never corrupts), which trades raw throughput for crash safety. strfry and nostr-rs-relay write durably by default, so a fair durable comparison runs Wisp in `meta`/`full` (see [benchmarks](docs/benchmarks.md)). Wisp leads on throughput (~9x strfry, ~5x nostr-rs-relay) and p99 latency; strfry stays smallest in memory.*
 
 ## Contributing
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,17 +11,17 @@
             .hash = "websocket-0.1.0-ZPISdV_aBACU9pGuvrTQ2z8uxz_Sp8JnJgQaiGKQIx1l",
         },
         .nostr = .{
-            .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.3.tar.gz",
-            .hash = "nostr-0.3.3-JY6OcOSaDwCoLI1RJOisJcxXrdzzP3Z57GyVBoC0wx2-",
+            .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.6.tar.gz",
+            .hash = "nostr-0.3.6-JY6OcLPKDwAP8UJz5qRAVc4LKg3AB2zE7Eok-gky9o4d",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Pinned to privkeyio fork commit
-        // 061104c (upstream karlseguin 5f60277 + a fix for a lost websocket read
-        // event that leaked connections under load, CLOSE_WAIT); upstream PR
-        // karlseguin/http.zig#212.
+        // 4c98859 (branch fix/websocket-nonblocking-lost-read-event), upstream PR
+        // karlseguin/http.zig#212: fixes lost EPOLLONESHOT websocket read events
+        // that leak connections (CLOSE_WAIT) and hang clients under load.
         .httpz = .{
-            .url = "https://github.com/privkeyio/http.zig/archive/061104c8e5a67dd22941da2d5f38f011550f5bc0.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrJLlCAClBJ52r0KravlJNK8UVNOSxnb4ppTlC_WG",
+            .url = "https://github.com/privkeyio/http.zig/archive/4c98859d4c04ce6a9c19330644bfa0f86f069b4f.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrPruCABsma9t2qIEL1R2DNPg9Zu8DjN6xhTZ2Rh0",
         },
     },
     .paths = .{

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,10 +9,13 @@ Peak write throughput, all relays at 100% delivery:
 | strfry | 2,800 | 2.9 ms | 3 MB |
 
 Measured with [nostr-bench](https://github.com/privkeyio/nostr-bench): 5,000 events x 4
-workers at peak rate (`--rate 0`), native release builds on a 16-core Linux host, default
-configs with the event-rate limit raised. `RssAnon` sampled during the run; figures are
-representative of three stable iterations.
+workers at peak rate (`--rate 0`), native release builds on a 16-core Linux host, with the
+event-rate limit raised. `RssAnon` sampled during the run; figures are representative of three
+stable iterations.
 
-Wisp leads on throughput (~9x strfry, ~5x nostr-rs-relay) and p99 latency; strfry stays
-smallest in memory. Wisp defaults to LMDB `MDB_NOSYNC` (fast, less crash-durable) while
-strfry writes durably, so part of the write-throughput gap reflects that tradeoff.
+This is peak write capability with Wisp in `sync = none` (non-durable). Wisp's **default is
+`sync = meta`** (durable, never corrupts), which trades raw throughput for crash safety; in
+the durable modes throughput scales with publisher concurrency because writes are
+group-committed (see [Configuration](configuration.md#durability)). strfry and nostr-rs-relay
+write durably by default, so a fair durable-vs-durable comparison runs Wisp in `meta`/`full`.
+On throughput and p99 latency Wisp leads; strfry stays smallest in memory.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,7 +62,7 @@ default. Settings with no environment variable are configurable only via the TOM
 |------|-----|------|---------|-------------|
 | `path` | `WISP_STORAGE_PATH` | string | `./data` | LMDB data directory. Point at `/dev/shm/wisp/data` (tmpfs) for lowest latency; data is then lost on reboot (see warning). |
 | `map_size_mb` | — | u32 | `10240` | LMDB maximum map size in MB. The hard upper bound on database size. |
-| `sync` | `WISP_STORAGE_SYNC` | enum | `none` | Write durability: `none`, `meta`, or `full`. See [Durability](#durability). |
+| `sync` | `WISP_STORAGE_SYNC` | enum | `meta` | Write durability: `none`, `meta`, or `full`. See [Durability](#durability). |
 
 > **Warning:** `/dev/shm` is volatile tmpfs — all data is lost on reboot. Use it only for
 > benchmarks or disposable caches. For production, point `path` at persistent storage and/or
@@ -75,18 +75,20 @@ crash safety:
 
 | Mode | Behavior | On crash / power loss |
 |------|----------|-----------------------|
-| `none` (default) | `MDB_NOSYNC` + `MDB_NOMETASYNC`: no flush on commit. Fastest. | Recent commits can be lost, and the database can be corrupted. |
-| `meta` | Flush data on every commit, defer only the metapage fsync. | The last transaction may roll back, but the database stays consistent. |
+| `none` | `MDB_NOSYNC` + `MDB_NOMETASYNC`: no flush on commit. Fastest. | Recent commits can be lost, and the database can be corrupted. |
+| `meta` (default) | Flush data on every commit, defer only the metapage fsync. | The last transaction may roll back, but the database stays consistent. |
 | `full` | Fsync on every commit. Durable. | No acknowledged write is lost. |
 
 In the durable modes (`meta`/`full`) writes go through a group-commit writer
 thread: events that arrive close together are committed in one transaction, so a
 batch pays a single fsync rather than one per event. Throughput therefore scales
-with how many clients publish concurrently. The default `none` mode keeps the
-faster synchronous write path, since there is no fsync to amortize.
+with how many clients publish concurrently.
 
-The default stays `none` to preserve current behavior; use `meta` for a good
-safety/throughput balance, or `full` when no acknowledged write may ever be lost.
+The default is `meta`: it never corrupts the database and at worst loses the last
+transaction on a crash. Use `full` when no acknowledged write may ever be lost, or
+`none` for maximum throughput on a relay where the data is disposable (a cache or
+benchmark) and a crash may corrupt the database. `none` uses a faster synchronous
+write path, since there is no fsync to amortize.
 
 ### `[limits]`
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -29,9 +29,9 @@ pub const Config = struct {
     max_future_seconds: i64,
     storage_path: []const u8,
     storage_map_size_mb: u32,
-    // LMDB durability: "none" (MDB_NOSYNC, fastest, can lose recent writes on
-    // crash), "meta" (flush data each commit, defer metapage fsync), or "full"
-    // (durable fsync each commit).
+    // LMDB durability: "none" (MDB_NOSYNC, fastest, can lose recent writes and
+    // corrupt the db on crash), "meta" (default; flush data each commit, defer
+    // metapage fsync), or "full" (durable fsync each commit).
     storage_sync: []const u8,
     idle_seconds: u32,
     events_per_minute: u32,
@@ -94,7 +94,7 @@ pub const Config = struct {
             .max_future_seconds = 900,
             .storage_path = "./data",
             .storage_map_size_mb = 10240,
-            .storage_sync = "none",
+            .storage_sync = "meta",
             .idle_seconds = 300,
             .events_per_minute = 120,
             .queries_per_minute = 300,

--- a/tests/integration_restrict.sh
+++ b/tests/integration_restrict.sh
@@ -30,8 +30,10 @@ chk() { # desc expected actual
 # TCP connection per attempt) should not fail the suite, while a real rejection
 # or a deterministic bug still reports reject after all attempts.
 pubres() { # noz-args...
-  for _ in 1 2 3; do
+  for attempt in 1 2 3; do
     if timeout 10 noz event "$@" "$R" 2>&1 | grep -q 'success'; then echo ok; return; fi
+    [ -n "${NOZ_DEBUG_RETRIES:-}" ] && echo "pubres: attempt $attempt failed [noz event $*]" >&2
+    [ "$attempt" -lt 3 ] && sleep 1
   done
   echo reject
 }

--- a/tests/integration_restrict.sh
+++ b/tests/integration_restrict.sh
@@ -25,9 +25,15 @@ chk() { # desc expected actual
   fi
 }
 
-# publish and report ok|reject based on whether the relay accepted the event
+# publish and report ok|reject based on whether the relay accepted the event.
+# Retries up to 3 times: a transient connect/read timeout under CI load (a fresh
+# TCP connection per attempt) should not fail the suite, while a real rejection
+# or a deterministic bug still reports reject after all attempts.
 pubres() { # noz-args...
-  if timeout 10 noz event "$@" "$R" 2>&1 | grep -q 'success'; then echo ok; else echo reject; fi
+  for _ in 1 2 3; do
+    if timeout 10 noz event "$@" "$R" 2>&1 | grep -q 'success'; then echo ok; return; fi
+  done
+  echo reject
 }
 
 case "$MODE" in

--- a/wisp.toml.example
+++ b/wisp.toml.example
@@ -15,10 +15,11 @@ description = "A lightweight Nostr relay"
 [storage]
 path = "./data"
 # map_size_mb = 10240
-# Write durability: "none" (fastest, can lose recent writes on crash), "meta"
-# (flush data each commit, defer metapage fsync), or "full" (durable fsync each
-# commit). Use "meta" or "full" for production data you cannot lose.
-# sync = "none"
+# Write durability: "meta" (default; flush data each commit, defer metapage
+# fsync, never corrupts), "full" (durable fsync each commit), or "none" (fastest
+# but a crash can lose recent writes and corrupt the db; use only for disposable
+# data).
+# sync = "meta"
 
 # Performance tip: For maximum throughput, use RAM-backed storage (tmpfs):
 #   path = "/dev/shm/wisp/data"


### PR DESCRIPTION
Flips the default storage sync mode from `none` to `meta` now that group-commit batching (#93) makes durable writes scale.

## Why

The previous default (`none` = `MDB_NOSYNC` + `MDB_NOMETASYNC` with `WRITEMAP`) is fast but a crash or power loss can not only lose recent events but corrupt the whole database. That is not a safe default for a relay people run in production.

`meta` flushes data on every commit and only defers the metapage fsync, so a crash at worst rolls back the last transaction and never corrupts the database. With the group-commit writer, durable throughput scales with publisher concurrency, so this is a reasonable default rather than a throughput cliff.

`none` remains available for disposable/cache relays that want maximum throughput, and `full` for never-lose-an-acked-write durability.

## Changes

- `config.zig`: default `storage_sync` `none` -> `meta`.
- `docs/configuration.md`: default markers and durability guidance updated.
- `docs/benchmarks.md`: clarifies the headline table is peak capability in `sync = none`; the default is now `meta` (durable), and a fair durable-vs-durable comparison runs Wisp in `meta`/`full`.
- `wisp.toml.example`: updated annotation.

## Verification

- Startup logs `sync=meta` by default; the integration suites (which do not set `WISP_STORAGE_SYNC`) now exercise the writer path by default: protocol 36/36, management 5/5.
- `zig build` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark writeups and the README footnote to clarify Wisp durability modes and the benchmarking durability setup.
  * Refreshed configuration documentation and example settings to match the new storage `sync` default.

* **Configuration**
  * Changed the default storage `sync` durability mode from `none` to `meta` for safer, durable storage commits.
  * Updated the changelog guidance to recommend `sync = none` only for maximum throughput on disposable data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->