### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-14
+
 ### Changed
 
 - Default storage `sync` mode is now `meta` (durable, never corrupts) instead of `none`; use `sync = none` for maximum throughput on disposable data
 - Updated libnostr-z to v0.3.6
-- Updated libnostr-z to v0.1.6
 
 ### Fixed
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.4.2",
+    .version = "0.5.0",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,7 +156,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.4.2 starting", .{});
+    std.log.info("Wisp v0.5.0 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.4.2\"");
+    try w.writeAll(",\"version\":\"0.5.0\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Cuts v0.5.0. Bumps the version (build.zig.zon, startup log, NIP-11 doc) and rolls the changelog.

Highlights:
- Storage `sync` now defaults to `meta` (durable, never corrupts) instead of `none` (#95). Operators upgrading get crash-safe writes by default; set `sync = none` for max throughput on disposable data.
- Fixed lost WebSocket read events under load that could leak connections (CLOSE_WAIT) and hang clients (http.zig PR #212 follow-up + libnostr-z v0.3.6 ws fixes).

After merge, tag v0.5.0 on the merge commit (I can cut the GitHub release).