### PR TITLE
Re-pin httpz to the simplified websocket lost-read fix

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,12 +16,13 @@
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Pinned to privkeyio fork commit
-        // 4c98859 (branch fix/websocket-nonblocking-lost-read-event), upstream PR
-        // karlseguin/http.zig#212: fixes lost EPOLLONESHOT websocket read events
-        // that leak connections (CLOSE_WAIT) and hang clients under load.
+        // 0694500 (branch fix/websocket-nonblocking-lost-read-event), upstream PR
+        // karlseguin/http.zig#212: fixes a lost EPOLLONESHOT websocket read that
+        // leaks connections (CLOSE_WAIT) and hangs clients under load, by releasing
+        // `processing` before re-arming the fd.
         .httpz = .{
-            .url = "https://github.com/privkeyio/http.zig/archive/4c98859d4c04ce6a9c19330644bfa0f86f069b4f.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrPruCABsma9t2qIEL1R2DNPg9Zu8DjN6xhTZ2Rh0",
+            .url = "https://github.com/privkeyio/http.zig/archive/06945003d534e048f8f3a16413685c07eb8872a7.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrIDeCAAPK5gkCAuTcCmqRfn0u65AYxxojzjsy-Pn",
         },
     },
     .paths = .{


### PR DESCRIPTION
Follow-up to v0.5.0. The upstream maintainer (karlseguin/http.zig#212) pointed out that the lost-read fix can be a simple reorder instead of the `pending`/`markPending` flag machinery: release `processing` before re-arming the fd.

Verified the reorder is sufficient and the flags are unnecessary:
- Deterministic 5ms-window injection: the old ordering hangs 10/10; the reorder passes 0/10.
- Statistical A/B (2 cores, raw auth publish): base 3/60 hung, reorder 0/60.
- Mechanism: a read arriving after the release dispatches a fresh worker normally, and a read already buffered is re-reported when rearmRead arms the readable fd.

This re-pins httpz from the flag-based commit (4c98859) to the simplified reorder commit (0694500), which is also now what PR #212 carries. Functionally equivalent fix, less code, and it avoids dangling on the rewritten PR branch (closes the concern in wisp-3uk).

Builds + tests pass; integration auth green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a core networking dependency to resolve critical WebSocket stability issues including unexpected hang conditions and resource leaks that could occur during socket read operations. This improves WebSocket connection reliability and ensures better overall application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->