### PR TITLE
Fix spider backoff escalating productive syncs into long blackouts

### DIFF
--- a/src/spider.zig
+++ b/src/spider.zig
@@ -15,8 +15,8 @@ fn milliTimestamp() i64 {
 const BATCH_SIZE: usize = 20;
 const BATCH_CREATION_DELAY_MS: u64 = 500;
 const RECONNECT_DELAY_MS: u64 = 10_000;
-const MAX_RECONNECT_DELAY_MS: u64 = 3600_000;
-const BLACKOUT_MS: u64 = 24 * 3600_000;
+const MAX_RECONNECT_DELAY_MS: u64 = 300_000;
+const BLACKOUT_MS: u64 = 30 * 60_000;
 const QUICK_DISCONNECT_MS: i64 = 30_000;
 const RATE_LIMIT_BACKOFF_MS: u64 = 60_000;
 const MAX_RATE_LIMIT_BACKOFF_MS: u64 = 1800_000;
@@ -325,8 +325,16 @@ pub const Spider = struct {
             if (!self.shouldRun()) break;
 
             if (success) {
-                if (connection_duration < QUICK_DISCONNECT_MS) {
-                    log.warn("{s}: Quick disconnect after {d}ms, waiting {d}ms", .{ relay_url, connection_duration, conn.reconnect_delay_ms });
+                if (conn.last_session_events > 0) {
+                    // A relay that delivered events is healthy even if it closed
+                    // quickly, which upstreams routinely do after serving a batch.
+                    // Keep the reconnect delay low so the feed stays current instead
+                    // of escalating the backoff toward a blackout.
+                    log.info("{s}: Synced {d} events in {d}ms", .{ relay_url, conn.last_session_events, connection_duration });
+                    conn.reconnect_delay_ms = RECONNECT_DELAY_MS;
+                    self.interruptibleSleep(5000);
+                } else if (connection_duration < QUICK_DISCONNECT_MS) {
+                    log.warn("{s}: Quick disconnect after {d}ms (no events), waiting {d}ms", .{ relay_url, connection_duration, conn.reconnect_delay_ms });
                     self.interruptibleSleep(conn.reconnect_delay_ms);
                     conn.reconnect_delay_ms = @min(conn.reconnect_delay_ms * 2, MAX_RECONNECT_DELAY_MS);
                 } else {
@@ -343,7 +351,7 @@ pub const Spider = struct {
             if (conn.reconnect_delay_ms >= MAX_RECONNECT_DELAY_MS) {
                 conn.blackout_until = milliTimestamp() + @as(i64, @intCast(BLACKOUT_MS));
                 conn.reconnect_delay_ms = RECONNECT_DELAY_MS;
-                log.warn("{s}: Entering 24h blackout", .{relay_url});
+                log.warn("{s}: Entering blackout after repeated failures", .{relay_url});
             }
         }
 
@@ -351,6 +359,7 @@ pub const Spider = struct {
     }
 
     fn connectAndSubscribe(self: *Spider, conn: *RelayConn, relay_url: []const u8) bool {
+        conn.last_session_events = 0;
         if (conn.isRateLimited()) {
             const wait_ms: u64 = @intCast(@max(0, conn.rate_limit_until - milliTimestamp()));
             log.info("{s}: Rate limited, waiting {d}ms", .{ relay_url, wait_ms });
@@ -425,7 +434,7 @@ pub const Spider = struct {
             return false;
         };
 
-        self.readLoop(&client, relay_url, subscribed_hash);
+        conn.last_session_events = self.readLoop(&client, relay_url, subscribed_hash);
 
         conn.last_disconnect = milliTimestamp();
         conn.state = .disconnected;
@@ -791,7 +800,7 @@ pub const Spider = struct {
         log.info("{s}: Sent {d} subscription batches", .{ relay_url, batch_idx });
     }
 
-    fn readLoop(self: *Spider, client: *websocket.Client, relay_url: []const u8, subscribed_hash: u64) void {
+    fn readLoop(self: *Spider, client: *websocket.Client, relay_url: []const u8, subscribed_hash: u64) u64 {
         var events_received: u64 = 0;
 
         client.readTimeout(1000) catch {};
@@ -819,7 +828,7 @@ pub const Spider = struct {
                 } else {
                     log.err("{s}: Read error: {}", .{ relay_url, err });
                 }
-                return;
+                return events_received;
             };
 
             if (message) |msg| {
@@ -831,6 +840,7 @@ pub const Spider = struct {
         }
 
         log.info("{s}: Read loop exiting, received {d} events", .{ relay_url, events_received });
+        return events_received;
     }
 
     fn handleRelayMessage(self: *Spider, data: []const u8, relay_url: []const u8, events_received: *u64) void {
@@ -966,6 +976,10 @@ const RelayConn = struct {
     rate_limit_backoff_ms: u64 = RATE_LIMIT_BACKOFF_MS,
     negentropy_supported: bool = true,
     active_client: ?*websocket.Client = null,
+    // Events synced during the most recent connection. A session that delivered
+    // events counts as productive even if it was short, so the reconnect backoff
+    // is not escalated for a relay that is healthy but closes after each batch.
+    last_session_events: u64 = 0,
 
     const State = enum { disconnected, connecting, connected };
 

--- a/src/spider.zig
+++ b/src/spider.zig
@@ -15,6 +15,7 @@ fn milliTimestamp() i64 {
 const BATCH_SIZE: usize = 20;
 const BATCH_CREATION_DELAY_MS: u64 = 500;
 const RECONNECT_DELAY_MS: u64 = 10_000;
+const HEALTHY_RECONNECT_DELAY_MS: u64 = 5_000;
 const MAX_RECONNECT_DELAY_MS: u64 = 300_000;
 const BLACKOUT_MS: u64 = 30 * 60_000;
 const QUICK_DISCONNECT_MS: i64 = 30_000;
@@ -332,7 +333,7 @@ pub const Spider = struct {
                     // of escalating the backoff toward a blackout.
                     log.info("{s}: Synced {d} events in {d}ms", .{ relay_url, conn.last_session_events, connection_duration });
                     conn.reconnect_delay_ms = RECONNECT_DELAY_MS;
-                    self.interruptibleSleep(5000);
+                    self.interruptibleSleep(HEALTHY_RECONNECT_DELAY_MS);
                 } else if (connection_duration < QUICK_DISCONNECT_MS) {
                     log.warn("{s}: Quick disconnect after {d}ms (no events), waiting {d}ms", .{ relay_url, connection_duration, conn.reconnect_delay_ms });
                     self.interruptibleSleep(conn.reconnect_delay_ms);
@@ -340,7 +341,7 @@ pub const Spider = struct {
                 } else {
                     log.info("{s}: Disconnected after {d}ms uptime", .{ relay_url, connection_duration });
                     conn.reconnect_delay_ms = RECONNECT_DELAY_MS;
-                    self.interruptibleSleep(5000);
+                    self.interruptibleSleep(HEALTHY_RECONNECT_DELAY_MS);
                 }
             } else {
                 log.warn("{s}: Connection failed, waiting {d}ms", .{ relay_url, conn.reconnect_delay_ms });
@@ -434,7 +435,7 @@ pub const Spider = struct {
             return false;
         };
 
-        conn.last_session_events = self.readLoop(&client, relay_url, subscribed_hash);
+        conn.last_session_events += self.readLoop(&client, relay_url, subscribed_hash);
 
         conn.last_disconnect = milliTimestamp();
         conn.state = .disconnected;
@@ -465,7 +466,6 @@ pub const Spider = struct {
             return false;
         };
 
-        var catchup_events: u64 = 0;
         const catchup_start = milliTimestamp();
         const catchup_timeout_ms: i64 = 30_000;
         var read_error = false;
@@ -479,11 +479,11 @@ pub const Spider = struct {
                 defer client.done(msg_data);
                 if (msg_data.data.len > 0) {
                     if (std.mem.startsWith(u8, msg_data.data, "[\"EOSE\"")) {
-                        log.info("{s}: Catch-up complete, received {d} events", .{ relay_url, catchup_events });
+                        log.info("{s}: Catch-up complete, received {d} events", .{ relay_url, conn.last_session_events });
                         break;
                     }
                     if (std.mem.startsWith(u8, msg_data.data, "[\"EVENT\"")) {
-                        self.handleRelayMessage(msg_data.data, relay_url, &catchup_events);
+                        self.handleRelayMessage(msg_data.data, relay_url, &conn.last_session_events);
                     }
                     if (std.mem.startsWith(u8, msg_data.data, "[\"NOTICE\"")) {
                         self.handleNotice(msg_data.data, relay_url);
@@ -497,18 +497,18 @@ pub const Spider = struct {
         }
 
         if (read_error) {
-            log.info("{s}: Catch-up finished with {d} events (connection lost)", .{ relay_url, catchup_events });
+            log.info("{s}: Catch-up finished with {d} events (connection lost)", .{ relay_url, conn.last_session_events });
             return false;
         }
 
         var close_buf: [64]u8 = undefined;
         const close_msg = std.fmt.bufPrint(&close_buf, "[\"CLOSE\",\"catchup\"]", .{}) catch {
-            log.info("{s}: Catch-up finished with {d} events", .{ relay_url, catchup_events });
+            log.info("{s}: Catch-up finished with {d} events", .{ relay_url, conn.last_session_events });
             return true;
         };
         client.writeText(@constCast(close_msg)) catch {};
 
-        log.info("{s}: Catch-up finished with {d} events", .{ relay_url, catchup_events });
+        log.info("{s}: Catch-up finished with {d} events", .{ relay_url, conn.last_session_events });
         return true;
     }
 
@@ -678,7 +678,7 @@ pub const Spider = struct {
         log.info("{s}: Need {d} events, have {d} events to skip", .{ relay_url, need_ids.items.len, have_ids.items.len });
 
         if (need_ids.items.len > 0) {
-            if (!self.fetchEventsByIds(client, relay_url, need_ids.items)) {
+            if (!self.fetchEventsByIds(client, relay_url, need_ids.items, conn)) {
                 return false;
             }
         }
@@ -686,9 +686,8 @@ pub const Spider = struct {
         return true;
     }
 
-    fn fetchEventsByIds(self: *Spider, client: *websocket.Client, relay_url: []const u8, ids: [][32]u8) bool {
+    fn fetchEventsByIds(self: *Spider, client: *websocket.Client, relay_url: []const u8, ids: [][32]u8, conn: *RelayConn) bool {
         const batch_size: usize = 100;
-        var fetched: u64 = 0;
         var i: usize = 0;
 
         while (i < ids.len) {
@@ -714,7 +713,7 @@ pub const Spider = struct {
 
             if (req_msg) |msg| {
                 client.writeText(@constCast(msg)) catch {
-                    log.info("{s}: Fetched {d} events via negentropy sync (connection lost)", .{ relay_url, fetched });
+                    log.info("{s}: Fetched {d} events via negentropy sync (connection lost)", .{ relay_url, conn.last_session_events });
                     return false;
                 };
             } else {
@@ -734,13 +733,13 @@ pub const Spider = struct {
                     defer client.done(msg);
                     if (std.mem.startsWith(u8, msg.data, "[\"EOSE\"")) break;
                     if (std.mem.startsWith(u8, msg.data, "[\"EVENT\"")) {
-                        self.handleRelayMessage(msg.data, relay_url, &fetched);
+                        self.handleRelayMessage(msg.data, relay_url, &conn.last_session_events);
                     }
                 }
             }
 
             if (read_error) {
-                log.info("{s}: Fetched {d} events via negentropy sync (connection lost)", .{ relay_url, fetched });
+                log.info("{s}: Fetched {d} events via negentropy sync (connection lost)", .{ relay_url, conn.last_session_events });
                 return false;
             }
 
@@ -754,7 +753,7 @@ pub const Spider = struct {
             i = end;
         }
 
-        log.info("{s}: Fetched {d} events via negentropy sync", .{ relay_url, fetched });
+        log.info("{s}: Fetched {d} events via negentropy sync", .{ relay_url, conn.last_session_events });
         return true;
     }
 
@@ -976,9 +975,11 @@ const RelayConn = struct {
     rate_limit_backoff_ms: u64 = RATE_LIMIT_BACKOFF_MS,
     negentropy_supported: bool = true,
     active_client: ?*websocket.Client = null,
-    // Events synced during the most recent connection. A session that delivered
-    // events counts as productive even if it was short, so the reconnect backoff
-    // is not escalated for a relay that is healthy but closes after each batch.
+    // Newly-stored events across the entire most recent session (negentropy
+    // first-sync, catch-up, and the live read loop combined). A session that
+    // delivered events counts as productive even if it was short, so the
+    // reconnect backoff is not escalated for a relay that is healthy but closes
+    // after each batch.
     last_session_events: u64 = 0,
 
     const State = enum { disconnected, connecting, connected };


### PR DESCRIPTION
Closes #97.

## Problem

A relay running spider against live upstreams pulled the initial feed fine, then went dark. Production logs showed all three upstream relays stuck in multi-hour blackouts:

```
info: wss://nos.lol: In blackout for 24179962ms more     # ~6.7 hours
info: wss://relay.damus.io: In blackout for 23879703ms more
info: wss://relay.nostr.band: In blackout for 22558153ms more
```

## Root cause

`relayLoop` classified any connection shorter than `QUICK_DISCONNECT_MS` (30s) as a failed "quick disconnect" and **doubled** the reconnect backoff. But upstream relays routinely close the connection after serving the historical batch, so a connection that synced thousands of events in ~20s was treated as a failure. After ~9 such "failures" the backoff hit the 1h cap and the relay entered a **24-hour blackout** (`BLACKOUT_MS = 24 * 3600_000`). Repeated across reconnects, the feed froze for hours.

## Fix

- **Track productivity.** `readLoop` now returns the events it received; `connectAndSubscribe` stores it on the connection. A session that delivered events resets the reconnect delay to its base regardless of how long it lasted, so a healthy-but-short connection no longer escalates. Only a connection that delivered **nothing** and dropped fast counts as a quick disconnect.
- **Sane caps.** `MAX_RECONNECT_DELAY_MS` 1h → 5m and `BLACKOUT_MS` 24h → 30m, so even a genuinely dead relay is retried within minutes, not abandoned for a day.

## Validation

Built and run against live relays (`--spider-admin <npub>`, 193-pubkey contact list) for 75s:

```
Synced (productive resets): 6      # e.g. "Synced 2620 events in 17393ms"
Quick disconnect (no events): 0
blackout entries: 0
```

Connections that previously triggered the 24h blackout now log `Synced N events` and reconnect promptly with the backoff reset. `zig build` + `zig build test` clean.

## Out of scope

The underlying `error.ReadFailed` (only on `wss://`/TLS connections, after the relay goes quiet) is why connections close after ~20s in the first place. It looks like the 1-second read timeout surfacing through the TLS read path as a generic error, which `readLoop` then treats as fatal. Root-causing that (for stable long-lived upstream connections) is a separate investigation; this PR makes the reconnect behavior correct regardless of why a connection ends.