### PR TITLE
Fix spider TLS read panic by polling for read readiness (#104)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,24 +4,29 @@
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the
-        // epoll worker-pool server. Pinned to a fixed commit for reproducible
-        // builds.
+        // epoll worker-pool server. Pinned to privkeyio fork commit ae78dce
+        // (branch fix/tls-read-timeout-poll): polls the socket for read readiness
+        // instead of SO_RCVTIMEO, so a read timeout on a wss/TLS connection
+        // surfaces as WouldBlock instead of an EAGAIN that std.crypto.tls's reader
+        // turns into a debug-build panic (programmer-bug syscall AGAIN). Upstream
+        // PR pending; repoint to karlseguin once merged.
         .websocket = .{
-            .url = "https://github.com/karlseguin/websocket.zig/archive/6d309f7a9790030f2fc070323b5defc64a15c13b.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdV_aBACU9pGuvrTQ2z8uxz_Sp8JnJgQaiGKQIx1l",
+            .url = "https://github.com/privkeyio/websocket.zig/archive/ae78dced086d70f6f09496e1b0f08ff7e201885f.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdabeBACg8O0rJ-ZIWbkoyY17EDn_9nGP1Yn7MZ3V",
         },
         .nostr = .{
             .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.6.tar.gz",
             .hash = "nostr-0.3.6-JY6OcLPKDwAP8UJz5qRAVc4LKg3AB2zE7Eok-gky9o4d",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
-        // websocket.zig's epoll worker pool. Pinned to upstream commit 80a76dd,
-        // the merge of karlseguin/http.zig#212: fixes a lost EPOLLONESHOT websocket
-        // read that leaks connections (CLOSE_WAIT) and hangs clients under load, by
-        // releasing `processing` before re-arming the fd.
+        // websocket.zig's epoll worker pool. Pinned to privkeyio fork commit
+        // ff5345d = upstream 80a76dd (merge of karlseguin/http.zig#212) with its
+        // websocket pin bumped to the same fork wisp uses, so the two websocket
+        // deps dedupe. Repoint to upstream once the websocket TLS-read fix lands
+        // upstream and http.zig bumps its websocket pin.
         .httpz = .{
-            .url = "https://github.com/karlseguin/http.zig/archive/80a76ddee50e348f0c6ce5ccb6ac860dbb510f20.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrIDeCAAPK5gkCAuTcCmqRfn0u65AYxxojzjsy-Pn",
+            .url = "https://github.com/privkeyio/http.zig/archive/ff5345d0927cf31b13b5c509531244d44485e6f3.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrMnfCAAzJ0XfcFMPFDFHDXTHXVzzDeBJ3c12V4Fa",
         },
     },
     .paths = .{


### PR DESCRIPTION
Closes #104.

## The crash

Building wisp with default `zig build` (debug) and running spider against live `wss://` relays core-dumps mid-sync:

```
thread panic: programmer bug caused syscall error: AGAIN
... std/Io/Threaded.zig netReadPosix .AGAIN => errnoBug
... std/crypto/tls/Client.zig stream
... websocket .../client.zig:447 read
... spider.zig readLoop
```

## Root cause

The spider sets a 1s read timeout (`SO_RCVTIMEO`) on its websocket client so the read loop can poll for shutdown / follow-list changes. On a plaintext (`ws://`) socket a timeout returns `EAGAIN` which websocket.zig's own posix wrapper maps to `error.WouldBlock` (handled as "no message"). But on a `wss://`/TLS socket the read goes through `std.crypto.tls`, whose `std` reader treats `EAGAIN` as a programmer bug and `std.debug.panic`s in debug builds (in ReleaseFast it returns an error and the connection just churns, which is why the shipped s9pk did not crash but reconnected constantly).

Both strfry (uWebSockets/epoll) and nostr-rs-relay (tokio) use readiness-based reads and never hit this.

## Fix

In websocket.zig's client `Stream`, implement the read timeout by **polling the fd for readiness** instead of `SO_RCVTIMEO`: a timeout surfaces as `error.WouldBlock` without ever issuing a read that can `EAGAIN`. The lib drains its own buffer before reaching the socket read, so polling only gates an actual socket read (no buffered-message hazard).

The fix lives in a websocket.zig fork (privkeyio/websocket.zig `fix/tls-read-timeout-poll`, upstream PR: https://github.com/karlseguin/websocket.zig/pull/103). Because http.zig also depends on websocket.zig, its pin is bumped to the same fork so the two `websocket` packages dedupe; this re-pins httpz to a privkeyio/http.zig fork = upstream `80a76dd` with only that websocket bump. Both repoint to upstream once the websocket fix lands.

## Verification

- The exact repro (debug build + spider vs live relays) that core-dumped within seconds now runs cleanly: **no panic**, and connections stay open far longer (one synced 1926 events over **109 s**, vs ~20 s before — the timeout now works instead of tearing the connection down, which also fixes the reconnect churn from #97/#100).
- `zig build test`, protocol suite 36/36 (exercises the httpz-fork relay server), spider suite 3/3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies for websocket and HTTP components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->