### PR TITLE
Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-06-18
+
+### Fixed
+
+- Spider no longer panics (debug builds) or churns through reconnects (release builds) on `wss://` upstream relays. The websocket client now polls for read readiness instead of using `SO_RCVTIMEO`, which on TLS connections surfaced a socket `EAGAIN` that crashed in debug and tore down connections in release. Upstream connections now stay open across quiet periods
+
 ## [0.5.1] - 2026-06-17
 
 ### Fixed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.5.1",
+    .version = "0.5.2",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,7 +156,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.5.1 starting", .{});
+    std.log.info("Wisp v0.5.2 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.5.1\"");
+    try w.writeAll(",\"version\":\"0.5.2\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Patch release. Version bump in `build.zig.zon`, the startup log, the NIP-11 document, and a changelog entry.

Since v0.5.1:
- **#106 (closes #104)** — fixes the spider TLS-read panic on `wss://` upstreams (debug-build core dump; reconnect churn in release). The websocket client polls for read readiness instead of `SO_RCVTIMEO`. Upstream connections now stay open across quiet periods. Pins privkeyio forks of websocket.zig + http.zig until the fix lands upstream (tracked in #107).