### PR TITLE
Fix inbound SIGSEGV: http.zig worker recv/disown use-after-free

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,13 +21,13 @@
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Pinned to privkeyio fork commit
-        // 9397b20 = upstream 80a76dd (merge of karlseguin/http.zig#212) with its
-        // websocket pin bumped to the same fork wisp uses, so the two websocket
-        // deps dedupe. Repoint to upstream once the websocket TLS-read fix lands
-        // upstream and http.zig bumps its websocket pin.
+        // 5a19b35 = upstream 80a76dd (merge of karlseguin/http.zig#212) plus the
+        // websocket pin bumped to the same fork wisp uses (dedup) and a worker fix
+        // for a recv/disown use-after-free (defer signal handling to batch end).
+        // Repoint to upstream once both land upstream (#107).
         .httpz = .{
-            .url = "https://github.com/privkeyio/http.zig/archive/9397b20f49f1058076a6817afbd9d9465a705474.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrMnfCAB4O_z19rqsi-29ELjMwZ_ydvu4NM2P_XEA",
+            .url = "https://github.com/privkeyio/http.zig/archive/5a19b35f458831a2bb961c7b4a531b208d135d35.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrEHjCACfZgQRiw4O7xPSV78YW-bMKKOmiZSRs36_",
         },
     },
     .paths = .{


### PR DESCRIPTION
Fixes the ~2.5-3h inbound SIGSEGV (wisp-startos#8). Root cause is in http.zig's epoll worker, not wisp.

## Trace (from a ReleaseSafe build)

```
Segmentation fault at address 0x2f8
httpz/src/worker.zig:1679:40 in getState
```

`getState()` does `@atomicLoad(&self._state)` with `self == null` (`0x2f8` is exactly `_state`'s offset in `HTTPConn`). It's called from the event loop's `.recv` branch.

## Root cause

In one epoll batch the loop can get a `.signal` and a `.recv` for the same connection. The `.signal` runs `processSignal` -> `disown`, which **frees** the connection (`http_conn_pool.release` + `conn_mem_pool.destroy`). The later `.recv` then dereferences that freed memory in `getState()`. This is the exact race http.zig's own comments warn about (worker.zig ~836-846); their mitigation only covers one path, and the `.recv` branch has no guard.

## Fix (in the http.zig fork)

Defer `processSignal` until the whole event batch is drained. Every `.recv` then runs while its connection is still alive, sees the `.handover` state that's set before the signal, and skips it (the existing `.active, .handover => continue` guard); the free happens safely afterward. Minimal, no lifecycle restructuring.

Carried in the privkeyio/http.zig fork (`5a19b35`); upstream PR to karlseguin/http.zig to follow, repoint tracked in #107.

## Validation

- `zig build` clean; protocol suite 36/36 (exercises request/websocket-upgrade/streaming/close), concurrency 2/2, and a sustained connection-churn stress with no crash. The ~3h race itself can't be reproduced locally; final validation is on the StartOS box with the ReleaseSafe build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP library dependency with fixes for connection handling issues and timing improvements that enhance stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->