### PR TITLE
Release v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-06-20
+
+### Fixed
+
+- Relay no longer crashes (SIGSEGV) a few hours into sustained inbound traffic. http.zig's epoll worker could process a `.signal` and a `.recv` for the same connection in one event batch; the signal freed the connection and the recv then dereferenced freed memory in `getState()`. The pinned http.zig fork now defers signal handling until the event batch is drained, so a freed connection is never touched. Confirmed in production: ran 13+ hours under load with no crash, versus crashing every ~3 hours before
+
 ## [0.5.3] - 2026-06-18
 
 ### Fixed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.5.3",
+    .version = "0.5.4",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,7 +156,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.5.3 starting", .{});
+    std.log.info("Wisp v0.5.4 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.5.3\"");
+    try w.writeAll(",\"version\":\"0.5.4\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Patch release. Version bump in `build.zig.zon`, the startup log, the NIP-11 document, and a changelog entry.

Since v0.5.3:
- **#111** — fixes the inbound SIGSEGV (~every 2.5-3h under load). http.zig's epoll worker could free a connection on a `.signal` and then dereference it on a `.recv` in the same event batch (`getState()` on a null `HTTPConn`). The pinned http.zig fork defers signal handling to the end of the event batch. **Confirmed in production: ran 13h+ under load with no crash, vs crashing every ~3h before.**

Uses the verified fork pins (privkeyio/http.zig `5a19b35` + websocket fork). The fork repoint to upstream is tracked separately in #107.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when signal and data events were received simultaneously for the same connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->