### PR TITLE
Release v0.5.7 (httpz shutdown use-after-free fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7] - 2026-06-27
+
+### Fixed
+
+- Relay no longer crashes (SIGSEGV) on shutdown when a query result stream is still in flight. http.zig's non-blocking worker freed its thread-pool arena without joining handler threads, so a SIGTERM landing mid-query (e.g. during a backup) let the handler keep iterating the store while LMDB was torn down underneath it. The pinned http.zig now joins in-flight handlers before teardown (karlseguin/http.zig#215). LMDB meta-sync meant no data was at risk, but the unclean abort is gone (#115)
+
 ## [0.5.6] - 2026-06-25
 
 ### Fixed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.5.6",
+    .version = "0.5.7",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll
@@ -17,11 +17,13 @@
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Upstream, includes the recv/disown
-        // use-after-free worker fix (karlseguin/http.zig#214) and the websocket
-        // pin bump (#213). Pins the same websocket commit as above so they dedup.
+        // worker use-after-free fix (karlseguin/http.zig#214), the shutdown
+        // use-after-free fix that joins in-flight handlers before deinit (#215),
+        // and the websocket pin bump (#213). Pins the same websocket commit as
+        // above so they dedup.
         .httpz = .{
-            .url = "https://github.com/karlseguin/http.zig/archive/5d1b4e2e3e5a30aa489bdb33321dae83897f2426.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrPjhCAAawzE3mV0uI1Hob-DYPBOZy_2Y0V_5ZbtY",
+            .url = "https://github.com/karlseguin/http.zig/archive/8dc64412ef3fc2c346f819af5ce80356a599fa5a.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrGPjCADaOd0dXNT-AbScFwnkdqJ_-r1cqjyO-vVj",
         },
     },
     .paths = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,7 +156,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.5.6 starting", .{});
+    std.log.info("Wisp v0.5.7 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.5.6\"");
+    try w.writeAll(",\"version\":\"0.5.7\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Bumps httpz to upstream `8dc6441`, which carries the shutdown use-after-free fix (karlseguin/http.zig#215).

Fixes #115: on SIGTERM with a query result stream in flight, http.zig's non-blocking worker freed its thread-pool arena without joining handler threads, so the handler kept iterating the store while LMDB was torn down -> SIGSEGV in `filtersMatch`. The new pin joins in-flight handlers before teardown. LMDB meta-sync meant no data was at risk; the unclean abort is gone.

websocket pin unchanged (http.zig still pins 99df0d3, so they dedup). Build clean, unit tests pass, boots without panic.

- httpz `5d1b4e2` -> `8dc6441`
- version 0.5.6 -> 0.5.7 + CHANGELOG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a shutdown crash that could occur when a query result was still being processed.
  * Improved shutdown handling to avoid accessing storage after it has been torn down.

* **Documentation**
  * Added the v0.5.7 release entry to the changelog.

* **Chores**
  * Bumped the app version to v0.5.7 and updated the server’s advertised version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->