### PR TITLE
Return 500 on NIP-11 serialization failure instead of unhandled exception

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -84,7 +84,17 @@ pub const App = struct {
                 res.header("Access-Control-Allow-Origin", "*");
                 res.header("Content-Type", "application/nostr+json");
                 const w = res.writer();
-                try nip11.write(app.config, app.nip86_handler, w);
+                // The writer buffers in memory (httpz flushes to the socket after
+                // this returns), so the only failure here is allocation failure
+                // while serializing the document. Reset the partial body and
+                // return 500 instead of serving a truncated 200 or letting it
+                // surface as an httpz "unhandled exception".
+                nip11.write(app.config, app.nip86_handler, w) catch |err| switch (err) {
+                    error.WriteFailed => {
+                        res.clearWriter();
+                        res.status = 500;
+                    },
+                };
                 return;
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of disconnected clients during root info responses, reducing unnecessary error logs and unhandled failures.
  * Requests that end mid-response are now ignored more gracefully, which helps avoid noisy alerts from monitors and brief disconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->