### PR TITLE
Release v0.5.8 (httpz epoll recv-on-freed-Conn fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.8] - 2026-06-29
+
+### Fixed
+
+- Relay no longer crashes (SIGSEGV) during normal operation under connection churn. http.zig's epoll worker closed a finished connection's socket on a worker thread to drop it from epoll, then recycled the connection object later; that close raced epoll_wait, so the fd could stay armed past the recycle and a later event batch delivered a read for freed memory (getState on a null/recycled connection). The pinned http.zig now removes the fd from epoll and closes it on the loop thread before the connection is recycled. Pinned to a temporary privkeyio http.zig fork; upstream PR karlseguin/http.zig#216, will repoint once merged (#120)
+
 ## [0.5.7] - 2026-06-27
 
 ### Fixed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.5.7",
+    .version = "0.5.8",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll
@@ -16,14 +16,16 @@
             .hash = "nostr-0.3.6-JY6OcLPKDwAP8UJz5qRAVc4LKg3AB2zE7Eok-gky9o4d",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
-        // websocket.zig's epoll worker pool. Upstream, includes the recv/disown
-        // worker use-after-free fix (karlseguin/http.zig#214), the shutdown
-        // use-after-free fix that joins in-flight handlers before deinit (#215),
-        // and the websocket pin bump (#213). Pins the same websocket commit as
-        // above so they dedup.
+        // websocket.zig's epoll worker pool. Temporary privkeyio fork of upstream
+        // 8dc6441 with one extra commit: remove a connection's fd from epoll on
+        // the loop thread before recycling the Conn, fixing a recv-on-freed-Conn
+        // segfault under connection churn (getState on a null HTTPConn). Carries
+        // the prior upstream fixes (#214 recv/disown, #215 shutdown join, #213
+        // websocket bump). Upstream PR pending; repoint once merged. Pins the
+        // same websocket commit as above so they dedup.
         .httpz = .{
-            .url = "https://github.com/karlseguin/http.zig/archive/8dc64412ef3fc2c346f819af5ce80356a599fa5a.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrGPjCADaOd0dXNT-AbScFwnkdqJ_-r1cqjyO-vVj",
+            .url = "https://github.com/privkeyio/http.zig/archive/0c6cd82eff5f2b1ded72462f5573c4c01ee0b509.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrF_nCAC5JmLxI3ov_IV60_nyISGr8fbGFpd_jj4b",
         },
     },
     .paths = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,7 +156,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.5.7 starting", .{});
+    std.log.info("Wisp v0.5.8 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.5.7\"");
+    try w.writeAll(",\"version\":\"0.5.8\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Fixes #120: a recurring SIGSEGV during normal operation under connection churn.

http.zig's epoll worker closed a finished connection's socket on a worker thread (to implicitly drop it from epoll), then recycled the Conn later via processSignal. That close raced epoll_wait, so the fd could stay armed past the recycle and a later batch delivered a `.recv` for freed memory -> `getState` on a null/recycled HTTPConn (fault at the `_state` offset). Confirmed reproducing on v0.5.7 every few hours.

The fix removes the fd from epoll and closes it on the loop thread, before disown recycles the Conn (mirroring the synchronous EPOLL_CTL_DEL that HTTPConn.disown already does for res.disown()).

Pinned to a temporary privkeyio http.zig fork (`0c6cd82`, = upstream `8dc6441` + the one fix). Upstream PR karlseguin/http.zig#216; will repoint to upstream and drop the fork once it merges.

- httpz pin -> privkeyio fork `0c6cd82`
- version 0.5.7 -> 0.5.8 + CHANGELOG

Verified: http.zig 125-test suite passes; wisp unit tests pass; survived 4000 connect/GET/close + partial-close churn cycles with no crash, then clean shutdown.