### PR TITLE
Release v0.5.9 (httpz shutdown buffer use-after-free fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.9] - 2026-06-29
+
+### Fixed
+
+- Relay no longer crashes (SIGSEGV) on shutdown when a query (REQ) was still being served as the relay stopped. The v0.5.7 shutdown fix joined the worker pool too late: http.zig freed the per-connection read buffers (in websocket.deinit) before joining in-flight handlers, and a REQ filter holds zero-copy slices into those buffers, so a handler still matching events read freed memory. The pinned http.zig now joins the worker pool before any connection buffers are freed. Completes the v0.5.7 fix (#115, upstream PR karlseguin/http.zig#217)
+
 ## [0.5.8] - 2026-06-29
 
 ### Fixed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.5.8",
+    .version = "0.5.9",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll
@@ -17,15 +17,16 @@
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Temporary privkeyio fork of upstream
-        // 8dc6441 with one extra commit: remove a connection's fd from epoll on
-        // the loop thread before recycling the Conn, fixing a recv-on-freed-Conn
-        // segfault under connection churn (getState on a null HTTPConn). Carries
-        // the prior upstream fixes (#214 recv/disown, #215 shutdown join, #213
-        // websocket bump). Upstream PR pending; repoint once merged. Pins the
-        // same websocket commit as above so they dedup.
+        // 8dc6441 with two extra commits: (1) remove a connection's fd from epoll
+        // on the loop thread before recycling the Conn, fixing a recv-on-freed-Conn
+        // segfault under churn (#120, upstream PR #216); (2) join the thread pool
+        // before websocket.deinit frees the connection read buffers, fixing a
+        // shutdown use-after-free in in-flight REQ filters (#115, completes #215,
+        // upstream PR #217). Carries the prior upstream fixes (#214, #213). Repoint
+        // once both merge. Pins the same websocket commit as above so they dedup.
         .httpz = .{
-            .url = "https://github.com/privkeyio/http.zig/archive/0c6cd82eff5f2b1ded72462f5573c4c01ee0b509.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrF_nCAC5JmLxI3ov_IV60_nyISGr8fbGFpd_jj4b",
+            .url = "https://github.com/privkeyio/http.zig/archive/edad9246b7ca4df4a7da1cf41d19113fccb1c111.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrEnoCADpf8B42EMPO2WmIlvsQJ0dJ8oCWjnl6CIX",
         },
     },
     .paths = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,7 +156,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.5.8 starting", .{});
+    std.log.info("Wisp v0.5.9 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.5.8\"");
+    try w.writeAll(",\"version\":\"0.5.9\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Reopens-and-fixes #115: the v0.5.7 shutdown join (karlseguin/http.zig#215) was placed after `websocket.deinit()`, which frees the per-connection read buffers. A REQ `Filter` holds zero-copy slices into those buffers, so a handler still in `filtersMatch` read freed memory before the join ran -> SIGSEGV at `filter.zig:285` on shutdown.

The pinned http.zig now hoists `thread_pool.stop()` to the top of the worker `deinit`, joining in-flight handlers before any connection state they read is freed. Upstream PR karlseguin/http.zig#217 (completes #215).

httpz pin -> privkeyio fork `edad924` = upstream `8dc6441` + the #120 epoll fix (PR #216) + this reorder (PR #217). Will repoint to upstream and drop the fork once both merge.

- httpz pin -> fork `edad924`
- version 0.5.8 -> 0.5.9 + CHANGELOG

Verified: http.zig builds + 125 tests pass; wisp builds, unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a shutdown crash that could occur while a query was still being served.
  * Improved shutdown handling to avoid freeing connection buffers too early.

* **Chores**
  * Updated the release version to **0.5.9** across the app and generated output.
  * Refreshed the bundled dependency to include the latest upstream fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->