### PR TITLE
Return cleanly on WS upgrade handshake WriteFailed instead of logging unhandled exception

### DIFF
--- a/src/server.zig
+++ b/src/server.zig
@@ -68,6 +68,7 @@ pub const App = struct {
                     log.warn("connection rejected (global limit): {s}", .{safeIp(client_ip, &log_ip_buf)});
                     return;
                 },
+                error.WriteFailed => return, // client disconnected during the upgrade handshake; nothing to send
                 else => return err,
             };
             if (upgraded == false) {


### PR DESCRIPTION
Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection handling so client disconnects during the upgrade handshake are handled gracefully without triggering a generic error path.
  * Preserved existing responses for other upgrade failures, including rate-limit and service-unavailable cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->