### PR TITLE
Fix WebSocket slot leak: shut down read half on idle close so the epoll worker reclaims the connection

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -101,11 +101,17 @@ pub const Connection = struct {
     /// another thread.
     pub fn closeWs(self: *Connection) void {
         if (self.ws_conn) |conn| {
+            // Bail if the worker already closed this connection. The fd may have
+            // been closed (and its number reused for another connection) by the
+            // worker's EOF path, which runs independently of write_guard; without
+            // this check the shutdown below could land on an unrelated fd. This
+            // mirrors the isClosed() guard the library's own conn.close() uses.
+            if (conn.isClosed()) return;
             // Don't close the fd off-thread: that bypasses the epoll worker's
             // cleanupConn/WsConn.close path and permanently leaks the connection
             // slot. Shutting down the read half keeps the fd in epoll but makes it
             // report EOF, so the worker wakes, reads 0 bytes, and runs its normal
-            // cleanup. This mirrors what the vendored library does internally.
+            // cleanup.
             _ = std.posix.system.shutdown(conn.stream.socket.handle, std.posix.SHUT.RD);
         }
     }

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -101,7 +101,12 @@ pub const Connection = struct {
     /// another thread.
     pub fn closeWs(self: *Connection) void {
         if (self.ws_conn) |conn| {
-            conn.close(.{}) catch {};
+            // Don't close the fd off-thread: that bypasses the epoll worker's
+            // cleanupConn/WsConn.close path and permanently leaks the connection
+            // slot. Shutting down the read half keeps the fd in epoll but makes it
+            // report EOF, so the worker wakes, reads 0 bytes, and runs its normal
+            // cleanup. This mirrors what the vendored library does internally.
+            _ = std.posix.system.shutdown(conn.stream.socket.handle, std.posix.SHUT.RD);
         }
     }
 


### PR DESCRIPTION
Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket shutdown handling by preventing close logic from running on connections that are already closed.
  * Updated the shutdown approach to signal EOF to the background worker so cleanup happens through the normal path, reducing the chance of connections lingering after disconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->