### PR TITLE
Release v0.5.10 (repoint httpz to upstream, drop fork)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.10] - 2026-07-01
+
+### Changed
+
+- Build against upstream `karlseguin/http.zig` instead of the temporary privkeyio fork. The two fixes the fork carried have merged upstream (the epoll recv-on-freed-Conn fix #216, and the shutdown-buffer join-order fix #217), so the pinned commit is byte-identical to the fork. No functional change from 0.5.9
+
 ## [0.5.9] - 2026-06-29
 
 ### Fixed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.5.9",
+    .version = "0.5.10",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll
@@ -16,16 +16,13 @@
             .hash = "nostr-0.3.6-JY6OcLPKDwAP8UJz5qRAVc4LKg3AB2zE7Eok-gky9o4d",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
-        // websocket.zig's epoll worker pool. Temporary privkeyio fork of upstream
-        // 8dc6441 with two extra commits: (1) remove a connection's fd from epoll
-        // on the loop thread before recycling the Conn, fixing a recv-on-freed-Conn
-        // segfault under churn (#120, upstream PR #216); (2) join the thread pool
-        // before websocket.deinit frees the connection read buffers, fixing a
-        // shutdown use-after-free in in-flight REQ filters (#115, completes #215,
-        // upstream PR #217). Carries the prior upstream fixes (#214, #213). Repoint
-        // once both merge. Pins the same websocket commit as above so they dedup.
+        // websocket.zig's epoll worker pool. Upstream, includes the epoll
+        // recv-on-freed-Conn fix (#216) and the shutdown-buffer join-order fix
+        // (#217), alongside the prior fixes (#215, #214, #213). Byte-identical to
+        // the temporary privkeyio fork it replaces. Pins the same websocket commit
+        // as above so they dedup.
         .httpz = .{
-            .url = "https://github.com/privkeyio/http.zig/archive/edad9246b7ca4df4a7da1cf41d19113fccb1c111.tar.gz",
+            .url = "https://github.com/karlseguin/http.zig/archive/86a44b63bda353338f2dbddc35eeb260f0f5c299.tar.gz",
             .hash = "httpz-0.0.0-PNVzrEnoCADpf8B42EMPO2WmIlvsQJ0dJ8oCWjnl6CIX",
         },
     },

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,7 +156,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.5.9 starting", .{});
+    std.log.info("Wisp v0.5.10 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.5.9\"");
+    try w.writeAll(",\"version\":\"0.5.10\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Both fixes the temporary privkeyio http.zig fork carried have merged upstream:
- karlseguin/http.zig#216 — epoll recv-on-freed-Conn fix (#120)
- karlseguin/http.zig#217 — shutdown-buffer join-order fix (#115)

So wisp repoints httpz to upstream `86a44b6` and drops the fork. The upstream commit is byte-identical to the fork pin (same Zig package hash), so there is no functional change from 0.5.9. websocket pin unchanged (upstream still pins 99df0d3, so they dedup).

- httpz pin -> upstream `86a44b6`
- version 0.5.9 -> 0.5.10 + CHANGELOG

Build clean, unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to **0.5.10** across startup messages and published metadata.
  * Updated release notes to reflect the new version.
  * Switched to the upstream build dependency now that the needed fixes are available there, with no expected functional change for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->