### PR TITLE
Add spider staleness watchdog to reconnect half-open relay connections

### DIFF
--- a/src/spider.zig
+++ b/src/spider.zig
@@ -24,6 +24,7 @@ const MAX_RATE_LIMIT_BACKOFF_MS: u64 = 1800_000;
 const CATCHUP_WINDOW_MS: i64 = 1800_000;
 const STALE_TIMEOUT_MS: i64 = 600_000;
 const STALE_PING_MS: i64 = 300_000;
+const PING_WRITE_TIMEOUT_MS: u32 = 5_000;
 
 fn isStale(last_data: i64, now: i64) bool {
     return now - last_data > STALE_TIMEOUT_MS;
@@ -811,6 +812,10 @@ pub const Spider = struct {
         var last_ping: i64 = last_data;
 
         client.readTimeout(1000) catch {};
+        // Bound the keepalive ping send: the handshake resets the write timeout
+        // to infinite, so without this a probe on a half-open socket (full send
+        // buffer) would block indefinitely instead of erroring into reconnect.
+        client.writeTimeout(PING_WRITE_TIMEOUT_MS) catch {};
 
         while (self.shouldRun()) {
             // Re-subscribe when the follow list changes (added, removed, or

--- a/src/spider.zig
+++ b/src/spider.zig
@@ -22,6 +22,7 @@ const QUICK_DISCONNECT_MS: i64 = 30_000;
 const RATE_LIMIT_BACKOFF_MS: u64 = 60_000;
 const MAX_RATE_LIMIT_BACKOFF_MS: u64 = 1800_000;
 const CATCHUP_WINDOW_MS: i64 = 1800_000;
+const STALE_TIMEOUT_MS: i64 = 600_000;
 
 pub const Spider = struct {
     allocator: std.mem.Allocator,
@@ -801,6 +802,7 @@ pub const Spider = struct {
 
     fn readLoop(self: *Spider, client: *websocket.Client, relay_url: []const u8, subscribed_hash: u64) u64 {
         var events_received: u64 = 0;
+        var last_data = milliTimestamp();
 
         client.readTimeout(1000) catch {};
 
@@ -832,8 +834,15 @@ pub const Spider = struct {
 
             if (message) |msg| {
                 defer client.done(msg);
+                last_data = milliTimestamp();
                 if (msg.data.len > 0) {
                     self.handleRelayMessage(msg.data, relay_url, &events_received);
+                }
+            } else {
+                const idle = milliTimestamp() - last_data;
+                if (idle > STALE_TIMEOUT_MS) {
+                    log.warn("{s}: No data for {d}s, forcing reconnect", .{ relay_url, @divTrunc(idle, 1000) });
+                    break;
                 }
             }
         }

--- a/src/spider.zig
+++ b/src/spider.zig
@@ -23,6 +23,11 @@ const RATE_LIMIT_BACKOFF_MS: u64 = 60_000;
 const MAX_RATE_LIMIT_BACKOFF_MS: u64 = 1800_000;
 const CATCHUP_WINDOW_MS: i64 = 1800_000;
 const STALE_TIMEOUT_MS: i64 = 600_000;
+const STALE_PING_MS: i64 = 300_000;
+
+fn isStale(last_data: i64, now: i64) bool {
+    return now - last_data > STALE_TIMEOUT_MS;
+}
 
 pub const Spider = struct {
     allocator: std.mem.Allocator,
@@ -803,6 +808,7 @@ pub const Spider = struct {
     fn readLoop(self: *Spider, client: *websocket.Client, relay_url: []const u8, subscribed_hash: u64) u64 {
         var events_received: u64 = 0;
         var last_data = milliTimestamp();
+        var last_ping: i64 = last_data;
 
         client.readTimeout(1000) catch {};
 
@@ -839,10 +845,23 @@ pub const Spider = struct {
                     self.handleRelayMessage(msg.data, relay_url, &events_received);
                 }
             } else {
-                const idle = milliTimestamp() - last_data;
-                if (idle > STALE_TIMEOUT_MS) {
-                    log.warn("{s}: No data for {d}s, forcing reconnect", .{ relay_url, @divTrunc(idle, 1000) });
+                const now = milliTimestamp();
+                if (isStale(last_data, now)) {
+                    log.warn("{s}: No data for {d}s, forcing reconnect", .{ relay_url, @divTrunc(now - last_data, 1000) });
                     break;
+                }
+                // Probe a quiet connection before giving up on it: a healthy
+                // relay's pong resets last_data, while a half-open socket stays
+                // silent until the stale timeout above fires. One probe per
+                // silence window (last_ping <= last_data means a frame has
+                // arrived since the last probe).
+                if (now - last_data > STALE_PING_MS and last_ping <= last_data) {
+                    var empty: [0]u8 = .{};
+                    client.writePing(&empty) catch |err| {
+                        log.info("{s}: Keepalive ping failed ({}), reconnecting", .{ relay_url, err });
+                        break;
+                    };
+                    last_ping = now;
                 }
             }
         }
@@ -1155,4 +1174,17 @@ fn decodeHexPayload(hex: []const u8, allocator: std.mem.Allocator) ![]u8 {
         return error.InvalidHex;
     };
     return out;
+}
+
+test isStale {
+    const testing = std.testing;
+    // Fresh and within the window: not stale.
+    try testing.expect(!isStale(1000, 1000));
+    try testing.expect(!isStale(1000, 1000 + STALE_PING_MS));
+    // Exactly at the timeout is still alive (strict >).
+    try testing.expect(!isStale(1000, 1000 + STALE_TIMEOUT_MS));
+    // One millisecond past the timeout is stale.
+    try testing.expect(isStale(1000, 1000 + STALE_TIMEOUT_MS + 1));
+    // A backward clock step must never report stale.
+    try testing.expect(!isStale(5000, 1000));
 }


### PR DESCRIPTION
Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a staleness watchdog to the relay read loop to detect and recover from stalled connections sooner.
  * When incoming data is silent for longer than the configured timeout, the loop now exits to trigger a reconnect.
  * During shorter silence windows, the system sends a probe ping to verify connectivity without interrupting normal message/event handling.
* **Tests**
  * Added unit tests for staleness detection, including boundary conditions and a backward-clock scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->