### PR TITLE
Harden connection reaping with SO_KEEPALIVE backstop and non-blocking idle reaper

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -262,9 +262,7 @@ fn storeCleanupThread(server: *Server, store: *Store, config: *const Config, sub
             const idle_ids = subs.getIdleConnections(config.idle_seconds);
             defer subs.allocator.free(idle_ids);
             for (idle_ids) |conn_id| {
-                var notice_buf: [128]u8 = undefined;
-                const notice = nostr.RelayMsg.notice("connection closed: idle timeout", &notice_buf) catch continue;
-                _ = subs.closeIdleConnection(conn_id, notice);
+                _ = subs.closeIdleConnection(conn_id);
             }
         }
 

--- a/src/server.zig
+++ b/src/server.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const httpz = @import("httpz");
 const websocket = httpz.websocket;
 const nostr = @import("nostr.zig");
@@ -258,16 +259,20 @@ pub const WsConn = struct {
         // Kernel-level backstop for dead/half-open peers. In the production topology
         // every client shares one internal IP behind the tunnel/reverse proxy, so
         // per-IP limits can't shed a stuck peer; keepalive lets the kernel reap it
-        // independently of the app-level idle reaper. ~2min to detect: 60s idle,
-        // then 4 probes 15s apart. TCP_* aren't in std.posix (Linux socket option
-        // numbers), so define them locally like TCP_NODELAY above.
-        const TCP_KEEPIDLE = 4;
-        const TCP_KEEPINTVL = 5;
-        const TCP_KEEPCNT = 6;
+        // independently of the app-level idle reaper. SO_KEEPALIVE is portable; the
+        // TCP_KEEP* idle/interval/count tuning uses Linux socket option numbers that
+        // mean other things on macOS (option 4 is TCP_NOPUSH), so gate it to Linux.
         std.posix.setsockopt(fd, std.posix.SOL.SOCKET, std.posix.SO.KEEPALIVE, &std.mem.toBytes(@as(i32, 1))) catch {};
-        std.posix.setsockopt(fd, std.posix.IPPROTO.TCP, TCP_KEEPIDLE, &std.mem.toBytes(@as(i32, 60))) catch {};
-        std.posix.setsockopt(fd, std.posix.IPPROTO.TCP, TCP_KEEPINTVL, &std.mem.toBytes(@as(i32, 15))) catch {};
-        std.posix.setsockopt(fd, std.posix.IPPROTO.TCP, TCP_KEEPCNT, &std.mem.toBytes(@as(i32, 4))) catch {};
+        if (builtin.os.tag == .linux) {
+            // ~2min to detect: 60s idle, then 4 probes 15s apart. These aren't in
+            // std.posix, so define them locally like TCP_NODELAY above.
+            const TCP_KEEPIDLE = 4;
+            const TCP_KEEPINTVL = 5;
+            const TCP_KEEPCNT = 6;
+            std.posix.setsockopt(fd, std.posix.IPPROTO.TCP, TCP_KEEPIDLE, &std.mem.toBytes(@as(i32, 60))) catch {};
+            std.posix.setsockopt(fd, std.posix.IPPROTO.TCP, TCP_KEEPINTVL, &std.mem.toBytes(@as(i32, 15))) catch {};
+            std.posix.setsockopt(fd, std.posix.IPPROTO.TCP, TCP_KEEPCNT, &std.mem.toBytes(@as(i32, 4))) catch {};
+        }
         errdefer connection.deinit();
 
         // Global connection limit + registry.

--- a/src/server.zig
+++ b/src/server.zig
@@ -255,6 +255,19 @@ pub const WsConn = struct {
         std.posix.setsockopt(fd, std.posix.IPPROTO.TCP, TCP_NODELAY, &std.mem.toBytes(@as(i32, 1))) catch {};
         const send_timeout = std.posix.timeval{ .sec = 10, .usec = 0 };
         std.posix.setsockopt(fd, std.posix.SOL.SOCKET, std.posix.SO.SNDTIMEO, &std.mem.toBytes(send_timeout)) catch {};
+        // Kernel-level backstop for dead/half-open peers. In the production topology
+        // every client shares one internal IP behind the tunnel/reverse proxy, so
+        // per-IP limits can't shed a stuck peer; keepalive lets the kernel reap it
+        // independently of the app-level idle reaper. ~2min to detect: 60s idle,
+        // then 4 probes 15s apart. TCP_* aren't in std.posix (Linux socket option
+        // numbers), so define them locally like TCP_NODELAY above.
+        const TCP_KEEPIDLE = 4;
+        const TCP_KEEPINTVL = 5;
+        const TCP_KEEPCNT = 6;
+        std.posix.setsockopt(fd, std.posix.SOL.SOCKET, std.posix.SO.KEEPALIVE, &std.mem.toBytes(@as(i32, 1))) catch {};
+        std.posix.setsockopt(fd, std.posix.IPPROTO.TCP, TCP_KEEPIDLE, &std.mem.toBytes(@as(i32, 60))) catch {};
+        std.posix.setsockopt(fd, std.posix.IPPROTO.TCP, TCP_KEEPINTVL, &std.mem.toBytes(@as(i32, 15))) catch {};
+        std.posix.setsockopt(fd, std.posix.IPPROTO.TCP, TCP_KEEPCNT, &std.mem.toBytes(@as(i32, 4))) catch {};
         errdefer connection.deinit();
 
         // Global connection limit + registry.

--- a/src/subscriptions.zig
+++ b/src/subscriptions.zig
@@ -61,7 +61,7 @@ pub const Subscriptions = struct {
         _ = self.connections.remove(conn_id);
     }
 
-    pub fn closeIdleConnection(self: *Subscriptions, conn_id: u64, notice: []const u8) bool {
+    pub fn closeIdleConnection(self: *Subscriptions, conn_id: u64) bool {
         const io = nostr.io.io();
         self.rwlock.lockSharedUncancelable(io);
         const conn = self.connections.get(conn_id);
@@ -69,11 +69,13 @@ pub const Subscriptions = struct {
         self.rwlock.unlockShared(io);
 
         const c = conn orelse return false;
-        // Write the notice outside the lock: a non-reading idle client would
-        // otherwise stall every lock waiter for up to the send timeout. The
-        // write_guard keeps the connection alive until the write completes.
+        // No courtesy NOTICE here: the reaper runs on the single cleanup thread,
+        // and a synchronous write to a non-reading idle client would stall it for
+        // up to the send timeout (per client), starving the other periodic jobs.
+        // closeWs() shuts down the read half so the worker still runs its normal
+        // cleanup and frees the slot/bucket. The write_guard keeps the connection
+        // alive until closeWs completes.
         defer _ = c.write_guard.fetchSub(1, .release);
-        c.write(notice) catch {};
         c.closeWs();
         return true;
     }


### PR DESCRIPTION
Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Idle websocket connections are now closed more reliably.
  * Connections can now use TCP keepalive checks to better detect dead or half-open peers, reducing the chance of stale sessions lingering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->