### PR TITLE
Make spider bootstrap shutdown-aware and off the accept path

### DIFF
--- a/src/spider.zig
+++ b/src/spider.zig
@@ -312,6 +312,16 @@ pub const Spider = struct {
         var conn = self.relays.getPtr(relay_url) orelse return;
 
         while (self.shouldRun()) {
+            const follow_empty = blk: {
+                self.follow_mutex.lockUncancelable(nostr.io.io());
+                defer self.follow_mutex.unlock(nostr.io.io());
+                break :blk self.follow_pubkeys.items.len == 0;
+            };
+            if (follow_empty) {
+                self.interruptibleSleep(1000);
+                continue;
+            }
+
             if (conn.blackout_until > 0) {
                 const now = milliTimestamp();
                 if (now < conn.blackout_until) {

--- a/src/spider.zig
+++ b/src/spider.zig
@@ -277,7 +277,12 @@ pub const Spider = struct {
         const interval_ms: u64 = @max(1000, @as(u64, self.config.spider_sync_interval) * 1000);
 
         self.refreshFollowList();
-        if (self.follow_pubkeys.items.len == 0) {
+        const initial_empty = blk: {
+            self.follow_mutex.lockUncancelable(nostr.io.io());
+            defer self.follow_mutex.unlock(nostr.io.io());
+            break :blk self.follow_pubkeys.items.len == 0;
+        };
+        if (initial_empty) {
             log.warn("Spider enabled but no pubkeys to follow", .{});
         }
 

--- a/src/spider.zig
+++ b/src/spider.zig
@@ -96,16 +96,8 @@ pub const Spider = struct {
         }
 
         self.running.store(true, .release);
-        self.refreshFollowList();
 
-        if (self.follow_pubkeys.items.len == 0) {
-            log.warn("Spider enabled but no pubkeys to follow", .{});
-        }
-
-        log.info("Spider starting with {d} relays, {d} pubkeys", .{
-            self.relays.count(),
-            self.follow_pubkeys.items.len,
-        });
+        log.info("Spider starting with {d} relays", .{self.relays.count()});
 
         for (self.relays.keys()) |relay_url| {
             const thread = try std.Thread.spawn(.{}, relayLoop, .{ self, relay_url });
@@ -178,6 +170,7 @@ pub const Spider = struct {
         _ = std.fmt.hexToBytes(&owner_pubkey, self.config.spider_admin) catch return;
 
         for (self.relays.keys()) |relay_url| {
+            if (!self.shouldRun()) return;
             log.info("Bootstrapping admin events from {s}...", .{relay_url});
 
             const parsed = parseRelayUrl(relay_url) orelse continue;
@@ -201,12 +194,12 @@ pub const Spider = struct {
 
             client.writeText(@constCast(req_msg)) catch continue;
 
-            client.readTimeout(5000) catch {};
+            client.readTimeout(1000) catch {};
 
             var events_received: u64 = 0;
             var got_kind3 = false;
             const bootstrap_start = milliTimestamp();
-            while (milliTimestamp() - bootstrap_start < 10_000) {
+            while (self.shouldRun() and milliTimestamp() - bootstrap_start < 10_000) {
                 const message = client.read() catch {
                     break;
                 };
@@ -282,6 +275,12 @@ pub const Spider = struct {
 
     fn refreshLoop(self: *Spider) void {
         const interval_ms: u64 = @max(1000, @as(u64, self.config.spider_sync_interval) * 1000);
+
+        self.refreshFollowList();
+        if (self.follow_pubkeys.items.len == 0) {
+            log.warn("Spider enabled but no pubkeys to follow", .{});
+        }
+
         while (self.shouldRun()) {
             self.interruptibleSleep(interval_ms);
 


### PR DESCRIPTION
Closes #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior so the app now logs a clearer “starting with relays” message and handles follow-list refreshes earlier in the background loop.
  * Follow-list warnings now appear when the list is empty, helping surface setup issues sooner.
  * Relay bootstrapping and event reading now stop more quickly when shutdown is requested, reducing unnecessary waiting and improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->