### PR TITLE
Relay ephemeral events (NIP-16) to subscribers instead of dropping them

### DIFF
--- a/src/handler.zig
+++ b/src/handler.zig
@@ -367,13 +367,14 @@ pub const Handler = struct {
             return;
         };
 
-        if (!result.stored) {
+        if (!result.stored and !result.ephemeral) {
             const success = std.mem.startsWith(u8, result.message, "duplicate");
             if (!success) metrics.eventRejected();
             self.replyOk(conn, id, success, result.message);
             return;
         }
 
+        // Stored, OR ephemeral (relayed but not persisted, NIP-01): ack and broadcast to subscribers.
         self.sendOk(conn, id, true, "");
         self.broadcaster.broadcast(&event);
     }

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -374,8 +374,10 @@ pub const Handler = struct {
             return;
         }
 
-        // Stored, OR ephemeral (relayed but not persisted, NIP-01): ack and broadcast to subscribers.
-        self.sendOk(conn, id, true, "");
+        // Stored, OR ephemeral (relayed but not persisted, NIP-16): ack and broadcast to subscribers.
+        // Ephemeral acks use replyOk so they are not miscounted as stored (sendOk records the stored
+        // metric); only genuinely persisted events go through sendOk.
+        if (result.ephemeral) self.replyOk(conn, id, true, "") else self.sendOk(conn, id, true, "");
         self.broadcaster.broadcast(&event);
     }
 

--- a/src/store.zig
+++ b/src/store.zig
@@ -24,6 +24,9 @@ pub const Store = struct {
         stored: bool,
         message: []const u8 = "",
         replaced_id: ?[32]u8 = null,
+        // NIP-01 ephemeral (20000-29999): relayed to subscribers but not persisted. The delivery
+        // paths broadcast when `stored OR ephemeral`, so this reaches subscribers despite stored=false.
+        ephemeral: bool = false,
     };
 
     pub fn init(allocator: std.mem.Allocator, lmdb: *Lmdb) !Store {
@@ -77,7 +80,7 @@ pub const Store = struct {
         const kind_type = nostr.kindType(event.kind());
 
         if (kind_type == .ephemeral) {
-            return .{ .stored = false, .message = "ephemeral: not stored" };
+            return .{ .stored = false, .ephemeral = true, .message = "ephemeral: not stored" };
         }
 
         const id = event.id();

--- a/src/store.zig
+++ b/src/store.zig
@@ -24,7 +24,7 @@ pub const Store = struct {
         stored: bool,
         message: []const u8 = "",
         replaced_id: ?[32]u8 = null,
-        // NIP-01 ephemeral (20000-29999): relayed to subscribers but not persisted. The delivery
+        // NIP-16 ephemeral (20000-29999): relayed to subscribers but not persisted. The delivery
         // paths broadcast when `stored OR ephemeral`, so this reaches subscribers despite stored=false.
         ephemeral: bool = false,
     };

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -30,6 +30,9 @@ const Processed = struct {
     success: bool,
     message: []const u8,
     broadcast: bool,
+    // Persisted to disk. Distinct from `broadcast`: ephemeral events (NIP-16) broadcast
+    // but are never stored, so they must not count as stored or invalidate the query cache.
+    stored: bool = false,
 };
 
 pub const Writer = struct {
@@ -155,7 +158,7 @@ pub const Writer = struct {
                 fatal = true;
                 break;
             };
-            if (p.success and p.broadcast) stored_any = true;
+            if (p.stored) stored_any = true;
             processed[n] = p;
             n += 1;
         }
@@ -178,7 +181,7 @@ pub const Writer = struct {
         if (stored_any) self.store.query_cache.invalidate();
 
         for (processed[0..n]) |*p| {
-            if (p.broadcast) metrics.eventStored() else if (!p.success) metrics.eventRejected();
+            if (p.stored) metrics.eventStored() else if (!p.success) metrics.eventRejected();
             self.reply(p.conn_id, p.event.id(), p.success, p.message);
             if (p.broadcast) self.broadcaster.broadcast(&p.event);
             p.event.deinit();
@@ -198,13 +201,13 @@ pub const Writer = struct {
                 _ = try self.store.deleteInTxn(txn, &target, event.pubkey());
             }
             _ = try self.store.storeInTxn(txn, event, job.json);
-            return .{ .conn_id = job.conn_id, .event = event.*, .success = true, .message = "", .broadcast = true };
+            return .{ .conn_id = job.conn_id, .event = event.*, .success = true, .message = "", .broadcast = true, .stored = true };
         }
 
         const result = try self.store.storeInTxn(txn, event, job.json);
-        // Stored, OR ephemeral (relayed but not persisted, NIP-01): ack and broadcast to subscribers.
+        // Stored, OR ephemeral (relayed but not persisted, NIP-16): ack and broadcast to subscribers.
         if (result.stored or result.ephemeral) {
-            return .{ .conn_id = job.conn_id, .event = event.*, .success = true, .message = "", .broadcast = true };
+            return .{ .conn_id = job.conn_id, .event = event.*, .success = true, .message = "", .broadcast = true, .stored = result.stored };
         }
         const dup = std.mem.startsWith(u8, result.message, "duplicate");
         return .{ .conn_id = job.conn_id, .event = event.*, .success = dup, .message = result.message, .broadcast = false };

--- a/src/writer.zig
+++ b/src/writer.zig
@@ -202,7 +202,8 @@ pub const Writer = struct {
         }
 
         const result = try self.store.storeInTxn(txn, event, job.json);
-        if (result.stored) {
+        // Stored, OR ephemeral (relayed but not persisted, NIP-01): ack and broadcast to subscribers.
+        if (result.stored or result.ephemeral) {
             return .{ .conn_id = job.conn_id, .event = event.*, .success = true, .message = "", .broadcast = true };
         }
         const dup = std.mem.startsWith(u8, result.message, "duplicate");

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -77,6 +77,20 @@ pub --sec $SEC1 -k 20000 -c "ephemeral"
 sleep 0.5
 chk "NIP-16 ephemeral not stored" 0 "$(req -k 20000)"
 
+# --- NIP-16 ephemeral is RELAYED LIVE to an open subscription (broadcast, not persisted) ---
+# Regression for the fix that lets ephemerals (20000-29999) reach subscribers despite not being
+# stored -- required by clients that coordinate over ephemeral events (e.g. keep's FROST/OPRF, kind
+# 24242). Subscribe first, publish while subscribed, and assert the subscriber received it.
+EPHOUT=$(mktemp)
+timeout 4 noz req -k 20001 "$R" >"$EPHOUT" 2>/dev/null &
+EPHPID=$!
+sleep 1
+pub --sec $SEC1 -k 20001 -c "live-ephemeral"
+wait $EPHPID
+chk "NIP-16 ephemeral delivered live to open subscription" 1 "$(grep -c '"kind"' "$EPHOUT")"
+chk "NIP-16 ephemeral still not stored after live delivery" 0 "$(req -k 20001)"
+rm -f "$EPHOUT"
+
 # --- NIP-33 addressable (kind 30023 + d tag) ---
 abase=$(($(date +%s) - 20))
 pub --sec $SEC2 -k 30023 -d slugA --ts $abase -c "A-v1"

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -80,14 +80,26 @@ chk "NIP-16 ephemeral not stored" 0 "$(req -k 20000)"
 # --- NIP-16 ephemeral is RELAYED LIVE to an open subscription (broadcast, not persisted) ---
 # Regression for the fix that lets ephemerals (20000-29999) reach subscribers despite not being
 # stored -- required by clients that coordinate over ephemeral events (e.g. keep's FROST/OPRF, kind
-# 24242). Subscribe first, publish while subscribed, and assert the subscriber received it.
+# 24242). `noz req` exits at EOSE, so it cannot observe a post-EOSE live broadcast; instead hold a
+# raw WebSocket open (via /dev/tcp), REQ, publish on a separate connection, and read the pushed frame.
+EPHHOSTPORT="${R#*://}"; EPHHOSTPORT="${EPHHOSTPORT%%/*}"
+EPHHOST="${EPHHOSTPORT%%:*}"; EPHPORT="${EPHHOSTPORT##*:}"
 EPHOUT=$(mktemp)
-timeout 4 noz req -k 20001 "$R" >"$EPHOUT" 2>/dev/null &
-EPHPID=$!
-sleep 1
-pub --sec $SEC1 -k 20001 -c "live-ephemeral"
-wait $EPHPID
-chk "NIP-16 ephemeral delivered live to open subscription" 1 "$(grep -c '"kind"' "$EPHOUT")"
+if exec 3<>"/dev/tcp/$EPHHOST/$EPHPORT"; then
+  printf 'GET / HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n' "$EPHHOSTPORT" >&3
+  while IFS= read -r line <&3; do [ "$line" = $'\r' ] && break; done
+  # Zero-masked client text frame (mask bit set, all-zero key leaves the payload as-is).
+  EPHREQ='["REQ","eph",{"kinds":[20001]}]'
+  printf "\x81\x$(printf %02x $((0x80 | ${#EPHREQ})))\x00\x00\x00\x00%s" "$EPHREQ" >&3
+  ( timeout 4 cat <&3 >"$EPHOUT" ) &
+  EPHPID=$!
+  sleep 1                                   # let the REQ register (relay also sends EOSE)
+  pub --sec $SEC1 -k 20001 -c "live-ephemeral"
+  wait $EPHPID
+  exec 3>&- 3<&-
+fi
+# grep -a: the WebSocket frame headers are binary, so force a text scan of the payload.
+chk "NIP-16 ephemeral delivered live to open subscription" 1 "$(grep -ac '"EVENT"' "$EPHOUT")"
 chk "NIP-16 ephemeral still not stored after live delivery" 0 "$(req -k 20001)"
 rm -f "$EPHOUT"
 


### PR DESCRIPTION
Relay ephemeral events (NIP-16, kinds 20000-29999) to matching subscribers instead of dropping them. Ephemerals are still never persisted; they are now broadcast to open subscriptions, per NIP-01/16.

Before this, `Store.storeInTxn` returned `stored = false` for ephemeral kinds and both delivery paths (`handler.zig` non-durable, `writer.zig` durable) treated any `stored = false` as "don't broadcast", so ephemeral events reached no one. That breaks clients that coordinate over ephemeral events , notably privkey's own keep FROST/OPRF protocol, whose entire coordination (announces, attestation, unlock) rides on kind 24242 (`keep-frost-net` `KFP_EVENT_KIND`), so wisp could not serve as its relay at all.

- **`src/store.zig`**: `StoreResult` gains an `ephemeral` flag; the ephemeral branch sets it (`stored = false, ephemeral = true`). Still not written to LMDB.
- **`src/handler.zig` / `src/writer.zig`**: broadcast when `stored OR ephemeral`.
- **`tests/integration.sh`**: new assertion , subscribe, publish an ephemeral while subscribed, confirm the subscriber receives it (and a post-hoc query still returns nothing, i.e. not stored).

Verified end-to-end beyond the unit test: with this build overridden into the keep-node appliance, its real OPRF-unlock nixosTest (relay swapped to wisp) now completes , the 2-of-2 quorum reconstructs the LUKS key coordinating entirely over wisp. Without this change it stalls at "no attested announce observed".
