### PR TITLE
Release v0.5.11 (NIP-16 ephemeral relay, spider + connection hardening)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.11] - 2026-07-07
+
+### Added
+
+- Ephemeral events (NIP-16, kinds 20000-29999) are now relayed to matching subscribers in real time instead of being dropped. They are still not stored (#143)
+- Nix packaging: a flake with a `wisp` package and a `services.wisp` NixOS module (host option, `LimitNOFILE`, conditional spider sandboxing, effective-port firewall) (#139)
+
+### Fixed
+
+- Spider reconnects half-open upstream relay connections via a staleness watchdog: quiet relays are probed with a keepalive ping (bounded by a write timeout) before a stale-connection reconnect, so silently dropped upstreams recover instead of hanging (#132)
+- Spider bootstrap is shutdown-aware and off the accept path: relay connect is gated until the follow list is populated, and the follow list is read under its mutex during the refresh-loop startup (#137)
+- Connection reaping hardened with an `SO_KEEPALIVE` backstop and a non-blocking idle reaper, so half-open and idle client connections are reclaimed reliably; TCP keepalive tuning is gated to Linux to avoid macOS corking (#136)
+- Zig dependency fetch sets the fetchzip extension so GitHub codeload tarballs unpack correctly (#142)
+
 ## [0.5.10] - 2026-07-01
 
 ### Changed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.5.10",
+    .version = "0.5.11",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,7 +156,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.5.10 starting", .{});
+    std.log.info("Wisp v0.5.11 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.5.10\"");
+    try w.writeAll(",\"version\":\"0.5.11\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Cuts v0.5.11, covering the changes merged since v0.5.10.

### Added
- Ephemeral events (NIP-16) relayed to subscribers in real time instead of dropped (#143)
- Nix packaging: flake + `wisp` package + `services.wisp` module (#139)

### Fixed
- Spider staleness watchdog reconnects half-open upstream relays, with a bounded keepalive probe (#132)
- Spider bootstrap made shutdown-aware and moved off the accept path (#137)
- Connection reaping hardened: `SO_KEEPALIVE` backstop + non-blocking idle reaper, Linux-gated keepalive tuning (#136)
- Zig dep fetch sets fetchzip extension so codeload tarballs unpack (#142)

Version bump + CHANGELOG. Deps unchanged (httpz/websocket on upstream). Build clean, unit tests pass.