### PR TITLE
Guard TLS read loop so quiet wss connections stop busy-spinning a core

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,26 +4,26 @@
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll
-        // worker-pool server. Upstream, includes the TLS read-readiness poll fix
-        // (karlseguin/websocket.zig#103). Must match http.zig's websocket pin so
+        // worker-pool server. privkeyio fork of karlseguin/websocket.zig#103
+        // that also polls inside the TLS read loop so a 0-plaintext control
+        // record can't busy-spin a core. Must match http.zig's websocket pin so
         // the two resolve to one package.
         .websocket = .{
-            .url = "https://github.com/karlseguin/websocket.zig/archive/99df0d3533a41cbcd5ff59b9af68bbfe6169cc62.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdangBAAgWPap_MVU6Nk4rj3GT3xuJuF0IIv8HN6G",
+            .url = "https://github.com/privkeyio/websocket.zig/archive/0c4dcc0c98d44d733dcf56605a43ac07e8b714b0.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdSzkBABfzRO9FT8LMxcqyqtPmTZG2HCSMi4aUHlY",
         },
         .nostr = .{
             .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.6.tar.gz",
             .hash = "nostr-0.3.6-JY6OcLPKDwAP8UJz5qRAVc4LKg3AB2zE7Eok-gky9o4d",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
-        // websocket.zig's epoll worker pool. Upstream, includes the epoll
-        // recv-on-freed-Conn fix (#216) and the shutdown-buffer join-order fix
-        // (#217), alongside the prior fixes (#215, #214, #213). Byte-identical to
-        // the temporary privkeyio fork it replaces. Pins the same websocket commit
-        // as above so they dedup.
+        // websocket.zig's epoll worker pool. privkeyio fork of karlseguin/http.zig
+        // @86a44b63 (epoll recv-on-freed-Conn #216, shutdown-buffer join-order
+        // #217, plus #215/#214/#213), re-pinned only to the websocket fork above
+        // so both resolve to the same websocket package.
         .httpz = .{
-            .url = "https://github.com/karlseguin/http.zig/archive/86a44b63bda353338f2dbddc35eeb260f0f5c299.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrEnoCADpf8B42EMPO2WmIlvsQJ0dJ8oCWjnl6CIX",
+            .url = "https://github.com/privkeyio/http.zig/archive/7d821a6597332d9d56519dceb465be73a98581e6.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrEjoCAApBRfs-NRdLMIaAKyo_83LHVjoc82el0kh",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
         // record can't busy-spin a core. Must match http.zig's websocket pin so
         // the two resolve to one package.
         .websocket = .{
-            .url = "https://github.com/privkeyio/websocket.zig/archive/0c4dcc0c98d44d733dcf56605a43ac07e8b714b0.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdSzkBABfzRO9FT8LMxcqyqtPmTZG2HCSMi4aUHlY",
+            .url = "https://github.com/privkeyio/websocket.zig/archive/ca717bbb3c0b194a39247517f61ce7fd8fb221a8.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdQXnBAB-klQMhNQdQ5plXawGfh9I3Qa2-FpAJFc_",
         },
         .nostr = .{
             .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.6.tar.gz",
@@ -22,8 +22,8 @@
         // #217, plus #215/#214/#213), re-pinned only to the websocket fork above
         // so both resolve to the same websocket package.
         .httpz = .{
-            .url = "https://github.com/privkeyio/http.zig/archive/7d821a6597332d9d56519dceb465be73a98581e6.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrEjoCAApBRfs-NRdLMIaAKyo_83LHVjoc82el0kh",
+            .url = "https://github.com/privkeyio/http.zig/archive/17db5504dec91f1808804407f30343ce50d81617.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrEjoCAD8hYp9Q0E8cSC-kuGT2wdmIcS01QYY2hBH",
         },
     },
     .paths = .{


### PR DESCRIPTION
Residual CPU busy-spin: each connected wss (TLS) spider relay pinned a core even after the v0.5.11 idle poll fix. websocket.zig Stream.read polled the socket only on entry, then looped `stream(); if (n!=0) return n;` with no re-poll. A 0-plaintext decrypt (TLS post-handshake control record, e.g. NewSessionTicket/KeyUpdate) retried instantly, tight-spinning in userspace — matching the observed R-state, wchan=0, no-syscall threads.

Fix (privkeyio/websocket.zig fork `0c4dcc0`): move the poll gate inside the TLS read loop so each empty-plaintext iteration polls up to read_timeout_ms (surfacing WouldBlock -> null on a quiet socket) instead of spinning; short-circuit a zero-length buffer; poll the plain-TCP path too. EOF/close still propagates for reconnect. http.zig fork `7d821a6` re-pins only its websocket dependency to the same fork so both dedup to one package.

zig build and zig build test both exit 0 on 0.16.0.

Closes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pinned library sources to newer archive locations and hashes.
  * Aligned related dependency pins to keep builds consistent with the current supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->