### PR TITLE
Bound spider connect + TLS handshake window (issue #140 option a)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,12 +5,13 @@
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll
         // worker-pool server. privkeyio fork of karlseguin/websocket.zig#103
-        // that also polls inside the TLS read loop so a 0-plaintext control
-        // record can't busy-spin a core. Must match http.zig's websocket pin so
-        // the two resolve to one package.
+        // that polls inside the TLS read loop so a 0-plaintext control record
+        // can't busy-spin a core, and bounds the client connect + TLS handshake
+        // so a blackholed/stalling relay can't hang shutdown. Must match
+        // http.zig's websocket pin so the two resolve to one package.
         .websocket = .{
-            .url = "https://github.com/privkeyio/websocket.zig/archive/ca717bbb3c0b194a39247517f61ce7fd8fb221a8.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdQXnBAB-klQMhNQdQ5plXawGfh9I3Qa2-FpAJFc_",
+            .url = "https://github.com/privkeyio/websocket.zig/archive/6a28798afc98fd76cbb9ed33ebd8df1d20c8345e.tar.gz",
+            .hash = "websocket-0.1.0-ZPISda75BAAvTnubzaPHqgoknKvJOYZ6Z9lNJrdKxZ9r",
         },
         .nostr = .{
             .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.6.tar.gz",
@@ -22,8 +23,8 @@
         // #217, plus #215/#214/#213), re-pinned only to the websocket fork above
         // so both resolve to the same websocket package.
         .httpz = .{
-            .url = "https://github.com/privkeyio/http.zig/archive/17db5504dec91f1808804407f30343ce50d81617.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrEjoCAD8hYp9Q0E8cSC-kuGT2wdmIcS01QYY2hBH",
+            .url = "https://github.com/privkeyio/http.zig/archive/545eb1128dbfa72778f7976c7ec7704da610552b.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrEjoCABBjQq22SYBYRENp0a2qdPLFB1fN6CUoqAG",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,8 +10,8 @@
         // so a blackholed/stalling relay can't hang shutdown. Must match
         // http.zig's websocket pin so the two resolve to one package.
         .websocket = .{
-            .url = "https://github.com/privkeyio/websocket.zig/archive/38bf52cd3da2a950058263533d95c6f999ecf417.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdWL7BAAqB1NXF1seDaj72KvXQWhuTcDedyiIQET_",
+            .url = "https://github.com/privkeyio/websocket.zig/archive/a5893724ec77fd3301da5ea310d1bafabd4e4d37.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdZoDBQCs0t96It4G8_Drfccox68JoY22pSMglRF8",
         },
         .nostr = .{
             .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.6.tar.gz",
@@ -23,8 +23,8 @@
         // #217, plus #215/#214/#213), re-pinned only to the websocket fork above
         // so both resolve to the same websocket package.
         .httpz = .{
-            .url = "https://github.com/privkeyio/http.zig/archive/7c6c94cdd217c6c7350723795ec820f6f62692f2.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrEjoCABy6WzvBH0H4p9PWDBO7LSOgF_-mbkYyuYz",
+            .url = "https://github.com/privkeyio/http.zig/archive/39cf73cf6e184cef03adbb0db54db843ec95af1c.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrEjoCAAbA8ENodVDeLCIKd8ymzeyeJtf-UwVGak8",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,8 +10,8 @@
         // so a blackholed/stalling relay can't hang shutdown. Must match
         // http.zig's websocket pin so the two resolve to one package.
         .websocket = .{
-            .url = "https://github.com/privkeyio/websocket.zig/archive/6a28798afc98fd76cbb9ed33ebd8df1d20c8345e.tar.gz",
-            .hash = "websocket-0.1.0-ZPISda75BAAvTnubzaPHqgoknKvJOYZ6Z9lNJrdKxZ9r",
+            .url = "https://github.com/privkeyio/websocket.zig/archive/38bf52cd3da2a950058263533d95c6f999ecf417.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdWL7BAAqB1NXF1seDaj72KvXQWhuTcDedyiIQET_",
         },
         .nostr = .{
             .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.6.tar.gz",
@@ -23,8 +23,8 @@
         // #217, plus #215/#214/#213), re-pinned only to the websocket fork above
         // so both resolve to the same websocket package.
         .httpz = .{
-            .url = "https://github.com/privkeyio/http.zig/archive/545eb1128dbfa72778f7976c7ec7704da610552b.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrEjoCABBjQq22SYBYRENp0a2qdPLFB1fN6CUoqAG",
+            .url = "https://github.com/privkeyio/http.zig/archive/7c6c94cdd217c6c7350723795ec820f6f62692f2.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrEjoCABy6WzvBH0H4p9PWDBO7LSOgF_-mbkYyuYz",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,8 +10,8 @@
         // so a blackholed/stalling relay can't hang shutdown. Must match
         // http.zig's websocket pin so the two resolve to one package.
         .websocket = .{
-            .url = "https://github.com/privkeyio/websocket.zig/archive/a5893724ec77fd3301da5ea310d1bafabd4e4d37.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdZoDBQCs0t96It4G8_Drfccox68JoY22pSMglRF8",
+            .url = "https://github.com/privkeyio/websocket.zig/archive/2a03892da86e1162fc4bdd24f184d9dbb38bd6c5.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdZwDBQDIqrWLscR0yhzEU0geyMUg0s09ni9zqq5l",
         },
         .nostr = .{
             .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.6.tar.gz",
@@ -23,8 +23,8 @@
         // #217, plus #215/#214/#213), re-pinned only to the websocket fork above
         // so both resolve to the same websocket package.
         .httpz = .{
-            .url = "https://github.com/privkeyio/http.zig/archive/39cf73cf6e184cef03adbb0db54db843ec95af1c.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrEjoCAAbA8ENodVDeLCIKd8ymzeyeJtf-UwVGak8",
+            .url = "https://github.com/privkeyio/http.zig/archive/ecb1ade87b2f373f8517ee3e4ff296be92efda61.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrEjoCAAtfZH7vCTJLzyB3Hi-sKbCq7PfR9nTE_aM",
         },
     },
     .paths = .{


### PR DESCRIPTION
Addresses #140 (option a: bounded connect/TLS timeout); option (b) closeClient socket-abort deferred.

The spider's `Client.init` in the privkeyio/websocket.zig fork did an unbounded TCP connect and TLS handshake. A blackholed IP (dropped SYN, ~127s kernel connect) or a relay that completes TCP then stalls the TLS handshake would hang the spider thread inside `init()`. Because `RelayConn.closeClient()` is a no-op and `active_client` is assigned only after `init()` returns, `stop()`->`thread.join()` cannot abort a thread stuck in `init()`, so shutdown blocks past StartOS's 60s grace and the container is SIGKILLed.

Fork changes (`Client.init`):
- TCP connect is bounded by a manual non-blocking connect gated by `poll()` (the Threaded Io panics if asked for a connect timeout, so the Io-native deadline is unusable here). DNS still uses `HostName.lookup`.
- The TLS handshake is bounded by a watchdog thread that shuts the socket down after the timeout, forcing the blocking handshake read/write to fail instead of hanging (a socket receive timeout can't be used because it surfaces as EAGAIN, which `std.crypto.tls` treats as a bug and the existing read-loop fix deliberately avoids).
- New `Config.connect_timeout_ms` (default 10000), applied independently to each phase, so the spider's effective worst case is ~20s, well under the 60s grace. The TLS read-loop spin fix and reconnect/backoff behavior are untouched.

This re-pin only bumps the two forks; the fork diff lives in privkeyio/websocket.zig `spider-tls-read-poll-guard` and is re-pinned through privkeyio/http.zig so both resolve to a single websocket package.

Stacks on #146 (base = `fix/spider-tls-read-busy-spin`); the diff here is only the incremental re-pin. Retarget to `main` after #146 merges.

Residual: on-device shutdown-vs-stalling-relay verification still required (can't be exercised in the build env); option (b) (making `closeClient()` abort `active_client`'s socket) remains open.