### PR TITLE
Release v0.5.12 (spider TLS busy-spin + connect/handshake timeout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.12] - 2026-07-09
+
+### Fixed
+
+- Spider no longer busy-spins a CPU core per quiet `wss://` upstream relay. The TLS read loop retried on 0-plaintext control records (post-handshake NewSessionTicket/KeyUpdate) without re-polling; the pinned websocket.zig now re-polls inside the loop so a quiet socket parks instead of spinning (#145)
+- Spider connect and TLS handshake are now bounded by a timeout (default 10s each), so a blackholed or stalling upstream relay can no longer hang the spider thread through shutdown and cause a SIGKILL past the service grace period. Bounds connect + handshake, not DNS resolution (#140 tracks the residual) (#148)
+
+### Changed
+
+- Both fixes land via upstream `karlseguin/websocket.zig` (#103, #108) and `karlseguin/http.zig`; wisp pins upstream, no fork
+
 ## [0.5.11] - 2026-07-07
 
 ### Added

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,15 +1,17 @@
 .{
     .name = .wisp,
-    .version = "0.5.11",
+    .version = "0.5.12",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll
         // worker-pool server. Upstream, includes the TLS read-readiness poll fix
-        // (karlseguin/websocket.zig#103). Must match http.zig's websocket pin so
-        // the two resolve to one package.
+        // (#103), the in-loop re-poll that stops quiet wss connections busy-spinning
+        // a core (via #218/#219 pin bumps), and the bounded connect/TLS-handshake
+        // timeout (#108). Must match http.zig's websocket pin so the two resolve to
+        // one package.
         .websocket = .{
-            .url = "https://github.com/karlseguin/websocket.zig/archive/99df0d3533a41cbcd5ff59b9af68bbfe6169cc62.tar.gz",
-            .hash = "websocket-0.1.0-ZPISdangBAAgWPap_MVU6Nk4rj3GT3xuJuF0IIv8HN6G",
+            .url = "https://github.com/karlseguin/websocket.zig/archive/b70e733bc0d0ba0a98ff5fe5ef64d3017c85f369.tar.gz",
+            .hash = "websocket-0.1.0-ZPISdUoQBQC7zw1uSwbOEYdxZiTxNN4nf9RlWBsN0_Nd",
         },
         .nostr = .{
             .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.6.tar.gz",
@@ -18,12 +20,11 @@
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Upstream, includes the epoll
         // recv-on-freed-Conn fix (#216) and the shutdown-buffer join-order fix
-        // (#217), alongside the prior fixes (#215, #214, #213). Byte-identical to
-        // the temporary privkeyio fork it replaces. Pins the same websocket commit
-        // as above so they dedup.
+        // (#217), alongside the prior fixes (#215, #214, #213). Pins the same
+        // websocket commit (b70e733) as above so they dedup.
         .httpz = .{
-            .url = "https://github.com/karlseguin/http.zig/archive/86a44b63bda353338f2dbddc35eeb260f0f5c299.tar.gz",
-            .hash = "httpz-0.0.0-PNVzrEnoCADpf8B42EMPO2WmIlvsQJ0dJ8oCWjnl6CIX",
+            .url = "https://github.com/karlseguin/http.zig/archive/01dc09453ae50b82cc74ac2f90e9cd57e0b38500.tar.gz",
+            .hash = "httpz-0.0.0-PNVzrEnoCAAwAtnht2430lpr-ynyNpLeTpoy_-lmWyhD",
         },
     },
     .paths = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,7 +156,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.5.11 starting", .{});
+    std.log.info("Wisp v0.5.12 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.5.11\"");
+    try w.writeAll(",\"version\":\"0.5.12\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Repoints websocket.zig `99df0d3 -> b70e733` and http.zig `86a44b6 -> 01dc094` (which pins the same websocket), picking up two spider fixes that are now fully upstream. No fork.

### Fixed
- **Busy-spin (#145):** quiet `wss://` upstreams no longer pin a core. The TLS read loop retried on 0-plaintext control records without re-polling; upstream websocket.zig now re-polls inside the loop so a quiet socket parks.
- **Connect/handshake hang (#148 / #140 option a):** spider connect + TLS handshake are now bounded (`connect_timeout_ms`, default 10s each), so a blackholed/stalling relay can't hang the spider thread through shutdown and trigger a SIGKILL past the grace period. Bounds connect+handshake, not DNS (#140 tracks the residual).

Both fixes merged upstream: websocket.zig #103/#108, http.zig websocket-pin bumps #218/#219. Dedup verified (websocket `b70e733` resolves once), build + unit tests pass, boots clean.

Closes #145.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Wisp v0.5.12, including updated version information in startup logs and NIP-11 metadata.

* **Bug Fixes**
  * Prevented busy-spinning when connecting to quiet secure WebSocket relays.
  * Added connection and TLS handshake timeouts to help prevent shutdown hangs.

* **Documentation**
  * Added changelog details for the v0.5.12 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->