### PR TITLE
Advertise NIP-51 and add kind 10050 DM-relays replaceable test

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,19 @@ For more options, see `wisp.toml.example`.
 
 ## Features
 
-* NIPs: 1, 2, 9, 11, 13, 16, 33, 40, 42, 45, 50, 65, 70, 77, 86
+* NIPs: 1, 2, 9, 11, 13, 16, 33, 40, 42, 45, 50, 51, 65, 70, 77, 86
 * LMDB storage (no external database)
 * Spider mode for syncing events from external relays
 * Import/export to JSONL
 * Prometheus metrics at `GET /metrics`
+
+Marmot/MLS compatible: Wisp's generic NIP-16/NIP-33 handling stores and serves
+kind 10050 (DM/inbox relays, replaceable), 10051 (KeyPackage relays,
+replaceable), 30443 (KeyPackage, addressable) / legacy 443, and 1059 gift
+wraps, so Haven, WhiteNoise, and other Marmot clients work without extra setup.
+Gift wraps are stored and served like any other event; Wisp does not implement
+the NIP-17 recipient-only serving rule, so operators wanting to restrict who can
+read kind 1059 should enable AUTH (`auth_required`).
 
 ## Monitoring
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -41,7 +41,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
         try writeJsonString(w, contact);
     }
 
-    try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,65,70,77,86]");
+    try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,51,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
     try w.writeAll(",\"version\":\"0.5.12\"");
 

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -72,6 +72,15 @@ chk "NIP-16 replaceable kept single" 1 "$(req -k 0 -a "$PK2")"
 chk "NIP-16 replaceable keeps latest" "v2" \
   "$(timeout 10 noz req -k 0 -a "$PK2" "$R" 2>/dev/null | grep -o 'v[12]' | head -1)"
 
+# --- NIP-51 DM relays list (kind 10050, NIP-17 inbox) replaceable, latest wins ---
+dmbase=$(($(date +%s) - 20))
+pub --sec $SEC2 -k 10050 --ts $dmbase -t relay=wss://relay.one -c ""
+pub --sec $SEC2 -k 10050 --ts $((dmbase + 1)) -t relay=wss://relay.two -c ""
+sleep 0.5
+chk "NIP-51 kind 10050 kept single" 1 "$(req -k 10050 -a "$PK2")"
+chk "NIP-51 kind 10050 keeps latest" "wss://relay.two" \
+  "$(timeout 10 noz req -k 10050 -a "$PK2" "$R" 2>/dev/null | grep -oE 'wss://relay\.(one|two)' | head -1)"
+
 # --- NIP-16 ephemeral (kind 20000) not stored ---
 pub --sec $SEC1 -k 20000 -c "ephemeral"
 sleep 0.5


### PR DESCRIPTION
## Summary

Advertise NIP-51 in the NIP-11 document and regression-test kind 10050 (DM Relays List), the replaceable event a user publishes to advertise which relays should receive their gift-wrapped (kind 1059) private DMs. Haven and other Marmot/NIP-17 clients publish and read this against Wisp. Wisp's generic NIP-16 handling already stores and serves kind 10050 correctly; this PR makes the support explicit and tested.

## Changes

- **NIP-11:** add `51` to `supported_nips` (kind 10050 DM-relays list is a NIP-51 standard list).
- **README:** note Marmot/MLS compatibility for the replaceable/addressable/regular kinds Wisp handles generically.
- **Integration test:** publish two kind 10050 events with `relay` tags and assert single-stored + latest-wins.

## NIP-17

NIP-17 is intentionally **not** advertised. It requires relays to serve `kind:1059` gift wraps only to the p-tagged recipient (via NIP-42 AUTH); Wisp serves gift wraps generically with no per-recipient gating, so advertising NIP-17 would overstate the DM-metadata privacy guarantee. The README documents this and points operators to `auth_required` if they want to restrict kind 1059 reads. Recipient-scoped gating can be added later as a prerequisite to advertising NIP-17.

## Verification

Full protocol integration suite passes end-to-end against a live relay (40/40), including the new kind 10050 assertions. `zig build` and `zig build test` pass.

Closes #155
