### PR TITLE
Release v0.5.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.13] - 2026-07-16
+
+### Added
+
+- Advertise NIP-51 (lists) in the relay information document, and document + test relay support for Marmot MLS KeyPackage events (#158)
+
+### Changed
+
+- Shard the rate limiters and reuse broadcast scratch buffers to cut worker lock contention under load (#151)
+
 ## [0.5.12] - 2026-07-09
 
 ### Fixed

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.5.12",
+    .version = "0.5.13",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll

--- a/src/main.zig
+++ b/src/main.zig
@@ -156,7 +156,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.5.12 starting", .{});
+    std.log.info("Wisp v0.5.13 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,51,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.5.12\"");
+    try w.writeAll(",\"version\":\"0.5.13\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Updated the application version to **0.5.13**.
  * Updated the reported **NIP-11** metadata version to **0.5.13**.
* **New Features**
  * Added support for advertising **NIP-51 (lists)** in the relay information document.
* **Changed**
  * Improved runtime behavior under load by sharding rate limiters and reusing broadcast scratch buffers to reduce worker contention.
* **Tests**
  * Added/updated coverage for **Marmot MLS KeyPackage** events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->