### PR TITLE
Verify the Zig toolchain checksum and pin noz by commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Zig dependencies in build.zig.zon have no Dependabot ecosystem, and the Zig
+  # toolchain itself is fetched by checksum in ci.yml. Both are tracked by hand.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,20 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y liblmdb-dev libsecp256k1-dev libssl-dev
 
       - name: Setup Zig
+        env:
+          ZIG_VERSION: 0.16.0
+          # sha256 of zig-x86_64-linux-0.16.0.tar.xz, from ziglang.org/download/index.json
+          ZIG_SHA256: 70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
         run: |
-          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
+          set -euo pipefail
+          tarball="zig-x86_64-linux-$ZIG_VERSION.tar.xz"
+          # download to disk and verify before extracting: piping straight into
+          # tar executes whatever was served, with no chance to check it first
+          curl -fsSL --retry 3 -o "$tarball" \
+            "https://ziglang.org/download/$ZIG_VERSION/$tarball"
+          echo "$ZIG_SHA256  $tarball" | sha256sum -c -
+          tar -xJf "$tarball"
+          echo "$PWD/zig-x86_64-linux-$ZIG_VERSION" >> $GITHUB_PATH
 
       - name: Build
         run: zig build
@@ -46,15 +57,28 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y liblmdb-dev libsecp256k1-dev libssl-dev
 
       - name: Setup Zig
+        env:
+          ZIG_VERSION: 0.16.0
+          # sha256 of zig-x86_64-linux-0.16.0.tar.xz, from ziglang.org/download/index.json
+          ZIG_SHA256: 70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00
         run: |
-          curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
-          echo "$PWD/zig-x86_64-linux-0.16.0" >> $GITHUB_PATH
+          set -euo pipefail
+          tarball="zig-x86_64-linux-$ZIG_VERSION.tar.xz"
+          # download to disk and verify before extracting: piping straight into
+          # tar executes whatever was served, with no chance to check it first
+          curl -fsSL --retry 3 -o "$tarball" \
+            "https://ziglang.org/download/$ZIG_VERSION/$tarball"
+          echo "$ZIG_SHA256  $tarball" | sha256sum -c -
+          tar -xJf "$tarball"
+          echo "$PWD/zig-x86_64-linux-$ZIG_VERSION" >> $GITHUB_PATH
 
       - name: Build noz (nostr test client)
         env:
-          NOZ_VERSION: v0.2.1
+          # pinned by commit: a tag can be moved, a commit cannot
+          NOZ_COMMIT: 848a2e3acdcfd0c82364ee391cc50ec0784ea5f0
         run: |
-          git clone --depth 1 --branch "$NOZ_VERSION" https://github.com/privkeyio/noz "$RUNNER_TEMP/noz"
+          git clone --filter=blob:none https://github.com/privkeyio/noz "$RUNNER_TEMP/noz"
+          git -C "$RUNNER_TEMP/noz" checkout --detach "$NOZ_COMMIT"
           (cd "$RUNNER_TEMP/noz" && zig build -Doptimize=ReleaseFast)
           echo "$RUNNER_TEMP/noz/zig-out/bin" >> $GITHUB_PATH
 


### PR DESCRIPTION
## Summary

The CI toolchain was fetched and executed without any integrity check.

```
curl -L https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz | tar -xJ
```

The **version** was pinned, which is good, but nothing verified the bytes. The archive went straight from the network into `tar` and then onto `PATH` as the compiler that builds this relay. Anything able to affect that response, a compromised mirror or an intercepted connection, would have its output compiling and running in CI, and there was no point in the pipeline where a check could have failed. This ran in both jobs.

Now the tarball is downloaded to disk, verified against a pinned SHA-256 published by ziglang.org, and only extracted if it matches:

```
curl -fsSL --retry 3 -o "$tarball" "https://ziglang.org/download/$ZIG_VERSION/$tarball"
echo "$ZIG_SHA256  $tarball" | sha256sum -c -
tar -xJf "$tarball"
```

Also adds `-f` so an HTTP error page is a failure rather than something handed to `tar`, `--retry 3` for transient network faults, and `set -euo pipefail` so a failing check actually stops the step.

## noz pinned by commit

The integration job cloned `privkeyio/noz` at `--branch v0.2.1`. A tag is a moving pointer; a commit is not. Now pinned to `848a2e3`, which is what `v0.2.1` currently resolves to, so this is not a version change. Swapped `--depth 1` for `--filter=blob:none`, since a shallow clone cannot check out an arbitrary commit.

## Dependabot

Added for `github-actions`, weekly and grouped, matching the other repositories. Zig has no Dependabot ecosystem, so `build.zig.zon` and the toolchain checksum stay manual; the config records that.

## Test plan

Verified locally rather than by reading:

- [x] SHA-256 `70e49664...ba3d00` confirmed against the actual bytes served (55478392 bytes, matching the published size)
- [x] Full flow run end to end: download, `sha256sum -c` passes, extract, `zig version` reports `0.16.0`
- [x] **Negative control**: flipped a single byte at offset 1000000, `sha256sum -c` reports `FAILED` and exits 1, so the step aborts before `tar` runs
- [x] `noz` pin verified: `--filter=blob:none` clone plus `checkout --detach 848a2e3` succeeds, and `v0.2.1` resolves to that same commit
- [x] Both YAML files parse
- [x] Confirmed the Setup Zig block appeared exactly twice before editing, so neither job kept the unverified path

The checksum is per-platform and per-version; changing `ZIG_VERSION` requires updating `ZIG_SHA256` from the same index, and a mismatch fails loudly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly checks for GitHub Actions dependencies.
  * Improved build and integration checks with verified tool downloads and retry support.
  * Pinned integration tooling to a specific version for more consistent results.
  * Documented manual tracking requirements for select development dependencies and toolchain updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->