### PR TITLE
Pin the remaining actions and scope job permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,11 +18,15 @@ on:
 
 jobs:
   benchmark:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Clone nostr-bench
         run: git clone --depth 1 --branch v0.2.1 https://github.com/privkeyio/nostr-bench ../nostr-bench
@@ -31,7 +35,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y liblmdb-dev libsecp256k1-dev libssl-dev netcat-openbsd
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
 
@@ -85,7 +89,7 @@ jobs:
           python3 benchmark/compare.py benchmark/baseline.json benchmark/results.json
 
       - name: Upload results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: benchmark-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
 
@@ -45,6 +47,8 @@ jobs:
         run: zig build test
 
   integration:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       matrix:
         include:
@@ -26,7 +28,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -43,7 +47,7 @@ jobs:
         shell: bash
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
 
@@ -70,19 +74,24 @@ jobs:
         shell: pwsh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.artifact }}
           path: ${{ matrix.artifact }}.*
 
   docker:
+    permissions:
+      contents: read
+      packages: write
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -90,7 +99,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -99,7 +108,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true
@@ -107,20 +116,24 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
   release:
+    permissions:
+      contents: write
     needs: [build, docker]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           pattern: wisp-*
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: artifacts/**/*
           generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,13 @@ jobs:
         uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
           version: 0.16.0
+          # Released binaries are built from a cold Zig cache. use-cache covers
+          # the global and local Zig build-cache directories, which are restored
+          # from the GitHub Actions cache and are writable by other workflow runs
+          # in this repository. A release artifact should not be able to pick up
+          # compilation output that something other than this run produced.
+          # Costs a full rebuild per release, which is the right trade here.
+          use-cache: false
 
       - name: Build
         run: zig build -Doptimize=ReleaseFast


### PR DESCRIPTION
## Summary

Pins the eight action references that were still mutable tags, scopes `permissions` on all six jobs, and stops every checkout persisting the job token.

## Why now

#162 added Dependabot and fixed the unverified Zig toolchain download in `ci.yml`, but only `ci.yml` had its actions pinned. `benchmark.yml` and `release.yml` were untouched and still carried bare tags. The Dependabot run that followed made that visible: it bumped the pinned refs in `ci.yml` to new commit SHAs while the others simply moved from `@v4` to `@v7`, still mutable.

The release path is the part that matters. `docker/login-action` authenticates to ghcr.io and `docker/build-push-action` pushes the published image, and both were reached through tags their owners can move at any time. `softprops/action-gh-release` creates the release itself.

## Permissions

Assigned per job rather than blanket `contents: read`, because two jobs genuinely need write and a uniform rule would have broken the release:

| job | permission | why |
|---|---|---|
| `ci: build`, `ci: integration`, `benchmark`, `release: build` | `contents: read` | build and test only |
| `release: docker` | `contents: read`, `packages: write` | pushes to `ghcr.io/${{ github.repository }}` |
| `release: release` | `contents: write` | creates the GitHub release |

Every job previously ran with the default token scope.

## Audit after the change

| property | before | after |
|---|---|---|
| action refs pinned to a commit | 7/15 | **15/15** |
| jobs with explicit `permissions` | 0/6 | **6/6** |
| checkouts with `persist-credentials: false` | 1/5 | **5/5** |

## Test plan

- [x] All three workflow files parse as YAML after the rewrite
- [x] Each SHA resolved from the tag it replaces, so no version changes: `actions/checkout` v7.0.1, `download-artifact` v8.0.1, `upload-artifact` v7.0.1, `docker/build-push-action` v7.3.0, `docker/login-action` v4.6.0, `docker/metadata-action` v6.2.0, `mlugg/setup-zig` v2.2.1, `softprops/action-gh-release` v3.0.2
- [x] Job permissions derived from what each job actually does, read from its step list rather than assumed
- [ ] CI green

The release and docker jobs only run on tag pushes, so this PR's CI does not exercise them. Their permission scopes are the one part that will not be proven until the next release, which is worth knowing before cutting one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the security and reproducibility of automated benchmark, CI, and release workflows.
  * Restricted workflow permissions to read-only access where applicable.
  * Pinned build, packaging, artifact, and release actions to fixed versions.
  * Disabled persistent checkout credentials during automated jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->