### PR TITLE
Assert the vendored httpz matches upstream plus its recorded patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,23 @@ jobs:
       - name: Unit tests
         run: zig build test
 
+  vendor:
+    name: vendored httpz integrity
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # build.zig.zon depends on vendor/httpz by path, so the package manager no
+      # longer hashes it. This is what stands in for that hash.
+      - name: Verify vendor/httpz is upstream plus the recorded patch
+        run: ./scripts/verify-vendored-httpz.sh
+
   integration:
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Thank you for your interest in contributing to wisp! This document provides guid
 - [Pull Request Guidelines](#pull-request-guidelines)
 - [NIP Implementation Policy](#nip-implementation-policy)
 - [Breaking Changes](#breaking-changes)
+- [Vendored Dependencies](#vendored-dependencies)
 - [Documentation Requirements](#documentation-requirements)
 - [Development Setup](#development-setup)
 - [Code of Conduct](#code-of-conduct)
@@ -257,6 +258,30 @@ Breaking changes require careful consideration:
 - Removing support for a NIP
 - Changing the database schema
 - Modifying the wire protocol in incompatible ways
+
+## Vendored Dependencies
+
+`vendor/httpz` is a copy of [http.zig](https://github.com/karlseguin/http.zig) pinned to a specific
+upstream commit, carrying a small local patch. `build.zig.zon` refers to it by path, which means the
+Zig package manager does not hash it: without a check, an edit anywhere in those sources would pass
+review unnoticed.
+
+CI therefore asserts that `vendor/httpz` equals upstream at the pinned commit plus exactly the delta
+recorded in `vendor/httpz.patch`. Upstream is fetched by commit SHA rather than by release tarball,
+because a SHA is content-addressed and cannot drift.
+
+If you need to change the vendored sources:
+
+1. Edit the files under `vendor/httpz/` as usual.
+2. Run `scripts/regenerate-vendored-httpz-patch.sh`.
+3. Commit the regenerated `vendor/httpz.patch` alongside your change, and explain the local delta in
+   the PR. `vendor/httpz.patch` is the reviewable record of everything we changed, so keep it small
+   and prefer upstreaming fixes.
+
+To move to a new upstream commit, update `UPSTREAM_COMMIT` in both scripts and the comment in
+`build.zig.zon`, re-vendor the tree, then regenerate the patch.
+
+Verify locally with `./scripts/verify-vendored-httpz.sh`.
 
 ## Documentation Requirements
 

--- a/scripts/regenerate-vendored-httpz-patch.sh
+++ b/scripts/regenerate-vendored-httpz-patch.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Rewrite vendor/httpz.patch to match the current vendor/httpz tree.
+#
+# Run this after deliberately changing the vendored httpz sources, then review
+# the resulting patch: it is the complete record of how the vendored copy
+# differs from upstream, and it is what CI enforces.
+set -euo pipefail
+
+UPSTREAM_REPO="https://github.com/karlseguin/http.zig"
+UPSTREAM_COMMIT="01dc09453ae50b82cc74ac2f90e9cd57e0b38500"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+git clone --quiet --filter=blob:none --no-checkout "$UPSTREAM_REPO" "$tmp/upstream"
+git -C "$tmp/upstream" checkout --quiet "$UPSTREAM_COMMIT"
+rm -rf "$tmp/upstream/.git"
+
+cp -a "$repo_root/vendor/httpz" "$tmp/vendor"
+
+( cd "$tmp" && diff -ruN upstream vendor || true ) \
+    | sed -E 's/\t[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:.]+ [+-][0-9]{4}$//' > "$repo_root/vendor/httpz.patch"
+
+echo "wrote vendor/httpz.patch ($(wc -l < "$repo_root/vendor/httpz.patch") lines)"

--- a/scripts/verify-vendored-httpz.sh
+++ b/scripts/verify-vendored-httpz.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Assert that vendor/httpz is exactly upstream http.zig at the pinned commit plus
+# the delta recorded in vendor/httpz.patch.
+#
+# build.zig.zon depends on vendor/httpz by path, which means the Zig package
+# manager no longer hashes it. Nothing else in the repo would notice an edit to
+# 15k lines of vendored HTTP and WebSocket code, so this check stands in for the
+# hash that the path dependency removed.
+#
+# Upstream is fetched by commit SHA rather than by release tarball on purpose:
+# a SHA is content-addressed and cannot drift, whereas GitHub's generated
+# archives are not guaranteed to stay byte-identical over time.
+set -euo pipefail
+
+UPSTREAM_REPO="https://github.com/karlseguin/http.zig"
+UPSTREAM_COMMIT="01dc09453ae50b82cc74ac2f90e9cd57e0b38500"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+vendor_dir="$repo_root/vendor/httpz"
+patch_file="$repo_root/vendor/httpz.patch"
+
+[ -d "$vendor_dir" ] || { echo "missing $vendor_dir" >&2; exit 1; }
+[ -f "$patch_file" ] || { echo "missing $patch_file" >&2; exit 1; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+git clone --quiet --filter=blob:none --no-checkout "$UPSTREAM_REPO" "$tmp/upstream"
+git -C "$tmp/upstream" checkout --quiet "$UPSTREAM_COMMIT"
+
+got="$(git -C "$tmp/upstream" rev-parse HEAD)"
+if [ "$got" != "$UPSTREAM_COMMIT" ]; then
+    echo "upstream checkout resolved to $got, expected $UPSTREAM_COMMIT" >&2
+    exit 1
+fi
+rm -rf "$tmp/upstream/.git"
+
+cp -a "$vendor_dir" "$tmp/vendor"
+
+# Paths are relative to $tmp so the headers are stable across machines, and the
+# trailing mtimes are stripped so the output depends only on content.
+( cd "$tmp" && diff -ruN upstream vendor || true ) \
+    | sed -E 's/\t[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:.]+ [+-][0-9]{4}$//' > "$tmp/actual.patch"
+
+if diff -u "$patch_file" "$tmp/actual.patch" > "$tmp/drift.diff"; then
+    echo "vendor/httpz matches upstream $UPSTREAM_COMMIT plus vendor/httpz.patch"
+    exit 0
+fi
+
+cat >&2 <<EOF
+vendor/httpz does not match upstream $UPSTREAM_COMMIT plus vendor/httpz.patch.
+
+Either vendor/httpz was edited without updating the recorded patch, or the
+patch was changed without updating the tree. Review the drift below; if the
+vendored change is intended, regenerate the patch with:
+
+    scripts/regenerate-vendored-httpz-patch.sh
+
+EOF
+cat "$tmp/drift.diff" >&2
+exit 1

--- a/vendor/httpz.patch
+++ b/vendor/httpz.patch
@@ -1,0 +1,218 @@
+diff -ruN upstream/src/httpz.zig vendor/src/httpz.zig
+--- upstream/src/httpz.zig
++++ vendor/src/httpz.zig
+@@ -37,6 +37,13 @@
+     return @import("metrics.zig").write(writer);
+ }
+ 
++/// Connections accepted since start, read directly rather than scraped. Moves
++/// on every accept, before any handler runs, so it reports whether the accept
++/// loop itself is alive independently of the thread pool.
++pub fn connectionCount() usize {
++    return @import("metrics.zig").connectionCount();
++}
++
+ pub const Protocol = enum {
+     HTTP10,
+     HTTP11,
+diff -ruN upstream/src/metrics.zig vendor/src/metrics.zig
+--- upstream/src/metrics.zig
++++ vendor/src/metrics.zig
+@@ -86,6 +86,14 @@
+     metrics.connections.incr();
+ }
+ 
++/// Connections accepted since start. Incremented in the accept path before any
++/// handler runs, so it advances whenever the accept loop is alive even if the
++/// thread pool is saturated. Exposed for callers that need that as a liveness
++/// signal without scraping the Prometheus output.
++pub fn connectionCount() usize {
++    return @atomicLoad(usize, &metrics.connections.count, .monotonic);
++}
++
+ pub fn request() void {
+     metrics.requests.incr();
+ }
+diff -ruN upstream/src/worker.zig vendor/src/worker.zig
+--- upstream/src/worker.zig
++++ vendor/src/worker.zig
+@@ -408,6 +408,15 @@
+         // that alone) and the worker thread will process it.
+         handover_list: ConcurrentList(Conn(WSH)),
+ 
++        // WebSocket connections which have closed and whose Conn(WSH) wrapper +
++        // per-worker slot (self.len) must be reclaimed. The teardown of a ws
++        // connection happens on a thread-pool thread (processWebsocketData), but
++        // self.len and conn_mem_pool may only be touched on the event-loop
++        // thread. So the worker thread cleans up the ws.HandlerConn + socket and
++        // hands the wrapper here; the loop thread reaps it (see
++        // reapClosedWebsockets) and re-arms accept if it was full.
++        websocket_close_list: ConcurrentList(Conn(WSH)),
++
+         // A pool of HTTPConn objects. The pool maintains a configured min # of these.
+         // An HTTPConn is relatively expensive, since we pre-allocate all types
+         // of things (a Request.State and Response.State).
+@@ -488,6 +497,7 @@
+                 .request_list = .{},
+                 .handover_list = .{},
+                 .keepalive_list = .{},
++                .websocket_close_list = .{},
+                 .buffer_pool = buffer_pool,
+                 .conn_mem_pool = conn_mem_pool,
+                 .http_conn_pool = http_conn_pool,
+@@ -782,7 +792,15 @@
+ 
+             while (c) |conn| {
+                 c = conn.next;
+-                const http_conn = conn.protocol.http;
++                // The handover list must only ever contain HTTP connections: a
++                // connection is switched to .websocket here (below) and then
++                // removed from this list. If a race ever leaves a .websocket
++                // conn in the handover snapshot, skip it rather than misread the
++                // active union field as .http (which aborts the process).
++                const http_conn = switch (conn.protocol) {
++                    .http => |hc| hc,
++                    .websocket => continue,
++                };
+                 switch (http_conn.handover) {
+                     .close, .unknown => {
+                         closed_bool.* = true;
+@@ -821,14 +839,58 @@
+                         loop.switchToOneShot(conn) catch {
+                             metrics.internalError();
+                             closed_bool.* = true;
++                            // protocol is now .websocket, so disown() (which
++                            // reads protocol.http) must not be used here. Tear
++                            // the ws connection down directly on the loop thread.
+                             conn.close();
+-                            self.disown(conn);
++                            self.websocket.cleanupConn(hc);
++                            self.releaseSlot();
++                            self.conn_mem_pool.destroy(conn);
+                             continue;
+                         };
+                     },
+                     .keepalive => unreachable,
+                 }
+             }
++
++            self.reapClosedWebsockets(closed_bool);
++        }
++
++        // Runs on the event-loop thread. Reclaims the per-worker slot and frees
++        // the Conn(WSH) wrapper for every WebSocket connection that closed since
++        // the last pass. The socket and ws.HandlerConn were already torn down on
++        // the worker thread (processWebsocketData); closing the socket removed it
++        // from the event loop, so we must NOT call loop.remove here (the fd may
++        // have been recycled by a subsequent accept).
++        fn reapClosedWebsockets(self: *Self, closed_bool: *bool) void {
++            const io = self.io;
++            var wl = &self.websocket_close_list;
++            var c = blk: {
++                wl.mut.lockUncancelable(io);
++                defer wl.mut.unlock(io);
++                const head = wl.inner.head;
++                wl.inner = .{};
++                break :blk head;
++            };
++
++            while (c) |conn| {
++                c = conn.next;
++                closed_bool.* = true;
++                self.releaseSlot();
++                self.conn_mem_pool.destroy(conn);
++            }
++        }
++
++        // Reclaim one accept slot. Guarded because a double release would panic
++        // in ReleaseSafe (the StartOS/Docker build) and silently wrap to ~2^64 in
++        // ReleaseFast (the release build), which would disable the max_conn cap
++        // outright rather than fail loudly.
++        fn releaseSlot(self: *Self) void {
++            if (self.len == 0) {
++                log.err("connection slot accounting underflow", .{});
++                return;
++            }
++            self.len -= 1;
+         }
+ 
+         // Entry-point of our thread pool. `thread_buf` is a thread-specific buffer
+@@ -885,10 +947,10 @@
+             if (success == false) {
+                 ws_conn.close(.{ .code = 4997, .reason = "wsz" }) catch {};
+                 self.websocket.cleanupConn(hc);
+-                conn.releaseProcessing();
++                self.closeWebsocket(conn);
+             } else if (ws_conn.isClosed()) {
+                 self.websocket.cleanupConn(hc);
+-                conn.releaseProcessing();
++                self.closeWebsocket(conn);
+             } else {
+                 // Release `processing` before re-arming. With EPOLLONESHOT, re-arming
+                 // while still holding `processing` loses a read that arrives in the
+@@ -903,10 +965,21 @@
+                     log.debug("({f}) failed to add read event monitor: {}", .{ ws_conn.address, err });
+                     ws_conn.close(.{ .code = 4998, .reason = "wsz" }) catch {};
+                     self.websocket.cleanupConn(hc);
++                    self.closeWebsocket(conn);
+                 };
+             }
+         }
+ 
++        // Called from a thread-pool thread once a WebSocket connection has been
++        // fully torn down (socket closed, ws.HandlerConn cleaned up). Hands the
++        // Conn(WSH) wrapper to the event-loop thread, which owns self.len and
++        // conn_mem_pool, to reclaim the slot and free the wrapper. Mirrors the
++        // signal-based handover used for HTTP connections.
++        fn closeWebsocket(self: *Self, conn: *Conn(WSH)) void {
++            self.websocket_close_list.insert(self.io, conn);
++            self.loop.signal() catch |err| log.err("failed to signal worker: {}", .{err});
++        }
++
+         fn disown(self: *Self, conn: *Conn(WSH)) void {
+             const io = self.io;
+             const http_conn = conn.protocol.http;
+@@ -916,7 +989,7 @@
+                 .keepalive => self.keepalive_list.remove(io, conn),
+                 .active => unreachable,
+             }
+-            self.len -= 1;
++            self.releaseSlot();
+             self.http_conn_pool.release(http_conn);
+             self.conn_mem_pool.destroy(conn);
+         }
+@@ -970,6 +1043,11 @@
+             while (conn) |c| {
+                 const timeout = c.protocol.http.timeout;
+                 if (timeout > now) {
++                    // Detach the survivor from the expired prefix before it
++                    // becomes the head. Those nodes are about to be destroyed,
++                    // so a stale prev would leave this connection pointing into
++                    // memory the pool has recycled.
++                    c.prev = null;
+                     list.head = c;
+                     return .{ timed_out, count, timeout };
+                 }
+@@ -982,12 +1060,21 @@
+             return .{ timed_out, count, null };
+         }
+ 
++        // Releases connections that collectTimedOut already spliced out of their
++        // owning list. It must not go through disown(): that removes the node
++        // from request_list/keepalive_list a second time, and List.remove
++        // rewrites head/tail from a node that is no longer a member. The effect
++        // was that a sweep with both expired and surviving entries dropped every
++        // survivor from the list, so those connections never timed out and held
++        // a worker slot for the life of the process.
+         fn closeList(self: *Self, list: List(Conn(WSH))) void {
+             var conn = list.head;
+             while (conn) |c| {
+                 conn = c.next;
+                 c.close();
+-                self.disown(c);
++                self.releaseSlot();
++                self.http_conn_pool.release(c.protocol.http);
++                self.conn_mem_pool.destroy(c);
+             }
+         }
+ 


### PR DESCRIPTION
`build.zig.zon` depends on `vendor/httpz` by path, so the Zig package manager no longer hashes it. Nothing in the repo would notice an edit anywhere in 15k lines of vendored HTTP and WebSocket code, and reviewing that much vendored source by eye is not a control anyone can rely on.

CI now asserts that `vendor/httpz` equals upstream at the pinned commit plus exactly the delta recorded in `vendor/httpz.patch`. That patch file becomes the reviewable record of everything we changed, so a diff to a vendored dependency shows up as a diff to a small file instead of being invisible.

## Details

- Upstream is fetched by **commit SHA, not release tarball**. A SHA is content-addressed and cannot drift, whereas GitHub's generated archives are not guaranteed to stay byte-identical over time, so a pinned tarball hash would eventually produce false failures.
- The comparison strips diff timestamps and uses paths relative to a temp dir, so the output depends only on content and is stable across machines.
- `scripts/regenerate-vendored-httpz-patch.sh` rewrites the patch after a deliberate change; `CONTRIBUTING.md` documents the workflow and how to move to a new upstream commit.

The current delta is three files, all intentional: the WebSocket accept-stall slot reclamation and union guard, the timeout-sweep fix, and the accept-counter accessor used by the watchdog.

## Verification

The guard fails on drift, which matters more than it passing. Appending a single comment line to `vendor/httpz/src/router.zig` produced exit 1 with the drift printed; reverting it passed again.

It also caught real drift unprompted: the patch was generated before the timeout-sweep fix landed, and re-running the check on this branch flagged the three changed files rather than silently accepting them.

`zig build test` is green.
