### PR TITLE
Expose httpz accept counts and scope the watchdog to the accept loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/metrics` now also exposes httpz's own counters. `httpz_connections` counts accepted TCP connections before any handler runs, so reading it against `wisp_connections_total` (completed WebSocket upgrades) distinguishes an accept loop that is running while work backs up from one that is stuck (#168)
+
+### Fixed
+
+- Handler slowness or a saturated thread pool can no longer escalate to a watchdog restart. The watchdog's liveness veto counts accepts, and httpz counts an accept before any handler runs, so a probe that is accepted and then goes unanswered vetoes itself. That makes it strictly an accept-loop watchdog: only a relay that never accepts the probe at all can reach the exit path (#168)
+
 ## [0.5.15] - 2026-08-10
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,15 @@ accepted a connection since the previous probe. Connection refusals and local
 descriptor exhaustion are logged but never counted, since a restart fixes
 neither. Set `enabled = false` to opt out entirely.
 
+The accept check is what makes this specifically an *accept-loop* watchdog. httpz
+counts an accept before any handler runs, so a probe that is accepted and then
+goes unanswered vetoes itself: a relay whose handlers are slow or whose thread
+pool is saturated is degraded rather than wedged, and restarting it would turn a
+slowdown into an outage. Only a relay that never accepts the probe at all can
+reach the exit path. `httpz_connections` on `/metrics` is that same accept
+counter, so comparing it against `wisp_connections_total` (completed WebSocket
+upgrades) shows whether the accept loop is running while work backs up.
+
 Because the process exits deliberately, run wisp under something that restarts
 it (`--restart unless-stopped` for Docker, `Restart=always` for systemd).
 Without a supervisor, a wedge that used to leave a degraded relay running will
@@ -214,3 +223,11 @@ Operational metrics are served in Prometheus format at `GET /metrics` on the rel
 connection counts, events stored/rejected/broadcast, REQ totals, and rate-limit counters. The
 endpoint honors `ip_whitelist`/`ip_blacklist`, so restrict it there or at your reverse
 proxy/firewall if it should not be public.
+
+The `httpz_*` series come from the embedded HTTP server. The useful one is
+`httpz_connections`, which counts accepted TCP connections before any handler runs. Read
+against `wisp_connections_total` (completed WebSocket upgrades) it separates two states that
+look identical from outside: if accepts climb while upgrades stall, the accept loop is running
+and work is backing up; if accepts stop climbing while clients are still connecting, the accept
+loop itself is stuck. `httpz_timeout_request` and `httpz_timeout_keepalive` count connections
+reaped for holding a slot without completing a request.

--- a/scripts/regenerate-vendored-httpz-patch.sh
+++ b/scripts/regenerate-vendored-httpz-patch.sh
@@ -14,13 +14,14 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-git clone --quiet --filter=blob:none --no-checkout "$UPSTREAM_REPO" "$tmp/upstream"
+git -c gc.auto=0 -c maintenance.auto=false clone --quiet --filter=blob:none --no-checkout "$UPSTREAM_REPO" "$tmp/upstream"
 git -C "$tmp/upstream" checkout --quiet "$UPSTREAM_COMMIT"
 rm -rf "$tmp/upstream/.git"
 
 cp -a "$repo_root/vendor/httpz" "$tmp/vendor"
 
-( cd "$tmp" && diff -ruN upstream vendor || true ) \
-    | sed -E 's/\t[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:.]+ [+-][0-9]{4}$//' > "$repo_root/vendor/httpz.patch"
+( cd "$tmp" && diff -ruN --exclude=.git upstream vendor || true ) \
+    | sed -E -e 's/\t[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:.]+ [+-][0-9]{4}$//' \
+             -e "s/^diff -ruN '--exclude=\.git' /diff -ruN /" > "$repo_root/vendor/httpz.patch"
 
 echo "wrote vendor/httpz.patch ($(wc -l < "$repo_root/vendor/httpz.patch") lines)"

--- a/scripts/verify-vendored-httpz.sh
+++ b/scripts/verify-vendored-httpz.sh
@@ -25,7 +25,7 @@ patch_file="$repo_root/vendor/httpz.patch"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-git clone --quiet --filter=blob:none --no-checkout "$UPSTREAM_REPO" "$tmp/upstream"
+git -c gc.auto=0 -c maintenance.auto=false clone --quiet --filter=blob:none --no-checkout "$UPSTREAM_REPO" "$tmp/upstream"
 git -C "$tmp/upstream" checkout --quiet "$UPSTREAM_COMMIT"
 
 got="$(git -C "$tmp/upstream" rev-parse HEAD)"
@@ -39,8 +39,9 @@ cp -a "$vendor_dir" "$tmp/vendor"
 
 # Paths are relative to $tmp so the headers are stable across machines, and the
 # trailing mtimes are stripped so the output depends only on content.
-( cd "$tmp" && diff -ruN upstream vendor || true ) \
-    | sed -E 's/\t[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:.]+ [+-][0-9]{4}$//' > "$tmp/actual.patch"
+( cd "$tmp" && diff -ruN --exclude=.git upstream vendor || true ) \
+    | sed -E -e 's/\t[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:.]+ [+-][0-9]{4}$//' \
+             -e "s/^diff -ruN '--exclude=\.git' /diff -ruN /" > "$tmp/actual.patch"
 
 if diff -u "$patch_file" "$tmp/actual.patch" > "$tmp/drift.diff"; then
     echo "vendor/httpz matches upstream $UPSTREAM_COMMIT plus vendor/httpz.patch"

--- a/src/server.zig
+++ b/src/server.zig
@@ -161,6 +161,13 @@ pub const App = struct {
         res.header("Content-Type", "text/plain; version=0.0.4; charset=utf-8");
         const w = res.writer();
         try metrics.write(w, app.subs.connectionCount());
+        // httpz's own counters, chiefly httpz_connections. That one counts
+        // accepts, incremented before any handler runs, so comparing it against
+        // wisp_connections_total (completed WebSocket upgrades) is what tells an
+        // operator whether the accept loop is running but work is backing up, as
+        // opposed to the accept loop being stuck. It is the same signal the
+        // watchdog uses to decide a stalled probe is not a wedge.
+        try httpz.writeMetrics(w);
     }
 
     /// OPTIONS / — CORS preflight.

--- a/src/watchdog.zig
+++ b/src/watchdog.zig
@@ -75,6 +75,14 @@ const State = struct {
         // running, so the probe was starved (slow handler, saturated thread
         // pool) rather than wedged. Corroboration only ever clears failures, it
         // never adds any, so it can only make the watchdog less trigger-happy.
+        //
+        // Note this covers the probe's own connection: httpz counts an accept
+        // before any handler runs, so a probe that gets accepted and then goes
+        // unanswered vetoes itself. That is deliberate. It makes this strictly
+        // an accept-loop watchdog: a relay whose handlers are slow or whose
+        // thread pool is saturated is degraded, not wedged, and restarting it
+        // would turn a slowdown into an outage. Only a relay that never accepts
+        // the probe at all can reach the exit path.
         if (accepts_progressed) {
             self.consecutive_failures = 0;
             return .healthy;


### PR DESCRIPTION
Closes the remaining path by which the watchdog could restart a relay that was merely slow.

## The concern

The probe's `GET /` is dispatched through the same thread pool as WebSocket message processing. Sustained handler saturation delays the reply past the probe deadline without the accept loop being stuck at all, so in principle three missed probes could exit a relay that was degraded rather than wedged. `SO_SNDTIMEO` is 10s, so a client that stops reading can pin a handler thread for up to 10s per write.

## Where it actually stands

The liveness veto shipped with the watchdog already covers this, for a reason that was not written down: httpz increments its accept counter *before any handler runs*, so the probe's own connection bumps it. A probe that gets accepted and then goes unanswered therefore vetoes itself, and the exit path is unreachable unless the relay never accepts the probe at all.

That is the correct behavior, but nothing made it observable, in production or in a test. This PR fixes that and states the guarantee.

## Changes

- `/metrics` also serves httpz's counters. `httpz_connections` counts accepted TCP connections before any handler runs; read against `wisp_connections_total` (completed WebSocket upgrades) it separates two states that look identical from outside: accepts climbing while upgrades stall means the accept loop is running and work is backing up; accepts flat while clients are connecting means the accept loop itself is stuck. `httpz_timeout_request` / `httpz_timeout_keepalive` also show connections reaped for holding a slot.
- Documented the consequence in `docs/configuration.md` and in the code: this is strictly an **accept-loop** watchdog. A relay whose handlers are slow is degraded, not wedged, and restarting it would turn a slowdown into an outage.

## Verification

Against a running relay with a 2s watchdog interval and no other traffic, sampling `httpz_connections` across three intervals:

```
3 probes counted as accepts over 3 x 2s (delta 4, minus this sample's own accept)
```

Probes scale with elapsed intervals, so the result cannot be explained by the metrics scrapes themselves — each sample's own accept is counted before its body is rendered, which is why the delta is probes + 1. That establishes the mechanism the veto depends on. The decision logic itself (`stalled` + accepts progressed → healthy) is already covered by unit tests.

`zig build test` green at 52/52; the vendored httpz integrity check passes unchanged, since this touches `src/` only.
