### PR TITLE
Document capping connections per source at the edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `/metrics` now also exposes httpz's own counters. `httpz_connections` counts accepted TCP connections before any handler runs, so reading it against `wisp_connections_total` (completed WebSocket upgrades) distinguishes an accept loop that is running while work backs up from one that is stuck (#168)
 
+### Documentation
+
+- Documented how to cap concurrent connections per source address. `max_connections_per_ip` is applied at the WebSocket upgrade, so a connection that never sends a request does not reach it; `docs/deployment.md` now covers enforcing this at the edge, including the fact that the rule belongs on the public port rather than the relay port, since behind a proxy every connection arrives from `127.0.0.1` (#169)
+
 ### Fixed
 
 - Handler slowness or a saturated thread pool can no longer escalate to a watchdog restart. The watchdog's liveness veto counts accepts, and httpz counts an accept before any handler runs, so a probe that is accepted and then goes unanswered vetoes itself. That makes it strictly an accept-loop watchdog: only a relay that never accepts the probe at all can reach the exit path (#168)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,7 +172,7 @@ instead leave it stopped.
 |------|-----|------|---------|-------------|
 | `trust_proxy` | `WISP_TRUST_PROXY` | bool | `false` | Honor `X-Forwarded-For` / `X-Real-IP` for the client IP. Enable only behind a reverse proxy whose backend port is not directly reachable, or clients can spoof their IP. |
 | `trusted_proxies` | `WISP_TRUSTED_PROXIES` | csv | (empty) | IPs/prefixes of proxies whose forwarded headers are trusted. Empty with `trust_proxy=true` trusts any peer. |
-| `max_connections_per_ip` | `WISP_MAX_CONNECTIONS_PER_IP` | u32 | `10` | Per-IP concurrent connection cap. |
+| `max_connections_per_ip` | `WISP_MAX_CONNECTIONS_PER_IP` | u32 | `10` | Per-IP concurrent connection cap, applied at the WebSocket upgrade. A connection that never sends a request does not reach it; those are closed by the 10s request timeout instead. To cap concurrent TCP connections per source, see [Limiting connections per source](deployment.md#limiting-connections-per-source). |
 | `ip_whitelist` | `WISP_IP_WHITELIST` | csv | (empty) | If set, only these IPs/prefixes may connect. |
 | `ip_blacklist` | `WISP_IP_BLACKLIST` | csv | (empty) | These IPs/prefixes are refused. |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -31,3 +31,59 @@ Your relay is now live at `wss://relay.yourdomain.com`.
 > **Behind a proxy:** set `trust_proxy = true` in the `[security]` section of `wisp.toml` so
 > per-IP connection limits and IP allow/deny lists see the real client IP from Caddy's
 > `X-Forwarded-For` header instead of `127.0.0.1`.
+
+## Limiting connections per source
+
+`max_connections_per_ip` is applied during the WebSocket upgrade, because that is the first
+point at which wisp knows the client IP. A connection that completes the TCP handshake and
+then sends nothing never reaches it. Those connections are bounded — they are closed after
+`10s` if no request arrives — but until then they occupy a worker slot, so a single source can
+hold `max_conn` slots per worker by reconnecting.
+
+Capping concurrent connections per source address closes that, and it belongs at the edge,
+where connections arrive. **Apply it wherever the public port is, not on the relay port.**
+Behind a reverse proxy every connection reaches wisp from `127.0.0.1`, so a per-IP rule on the
+relay port would either do nothing or throttle the proxy itself.
+
+**Exposed directly** — limit on the relay port:
+
+```sh
+# nftables
+nft add rule inet filter input tcp dport 7777 ct count over 10 reject
+
+# iptables
+iptables -A INPUT -p tcp --dport 7777 \
+  -m connlimit --connlimit-above 10 --connlimit-mask 32 -j REJECT
+```
+
+**Behind a proxy** — limit on the public port instead:
+
+```sh
+iptables -A INPUT -p tcp --dport 443 \
+  -m connlimit --connlimit-above 10 --connlimit-mask 32 -j REJECT
+```
+
+Caddy has no built-in per-connection limiter, so with the Caddyfile above the firewall rule is
+the control. If you front wisp with nginx instead, it can do this itself:
+
+```nginx
+limit_conn_zone $binary_remote_addr zone=perip:10m;
+
+server {
+    listen 443 ssl;
+    location / {
+        limit_conn perip 10;
+        proxy_pass http://127.0.0.1:7777;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}
+```
+
+Set the limit above `max_connections_per_ip` (default 10) so the edge only rejects what wisp
+would have refused anyway. `--connlimit-mask 32` counts per address; lower it to limit per
+subnet. Note that any of these only constrain a single source: they do not help against a
+flood distributed across many addresses, which is what `max_conn` and the request timeout
+bound.


### PR DESCRIPTION
`max_connections_per_ip` is applied during the WebSocket upgrade, because that is the first point at which wisp knows the client IP. A connection that completes the TCP handshake and then sends nothing never reaches it.

Since the request timeout landed, those connections are bounded rather than permanent — they are closed after 10s if no request arrives — but until then a single source can occupy worker slots by reconnecting.

## Why this is documentation rather than code

httpz exposes no accept-level hook. Middleware, dispatchers and routers all run per request on the thread pool, so a connection that sends nothing reaches none of them; I checked the config struct and the httpz entry points and there is no callback carrying the peer address at accept time.

Closing this in-process would mean adding a hook to the vendored accept path. That is the hottest path in that tree, it would put a mutex and a hashmap lookup on the event-loop thread for every accept, and it works directly against re-pinning the vendored copy to upstream. Connection limiting also belongs at the edge, where connections arrive, and the kernel and nginx already do it well.

## What is documented

The firewall (`nftables` / `iptables connlimit`) and nginx (`limit_conn`) forms, plus the detail that gets this wrong in practice: **the rule belongs on the public port, not the relay port.** Behind a reverse proxy every connection reaches wisp from `127.0.0.1`, so a per-IP rule on the relay port either does nothing or throttles the proxy itself. Both topologies are covered separately.

It also states plainly what this does *not* do: none of these help against a flood distributed across many source addresses, which is what `max_conn` and the request timeout bound.

Caddy is the proxy in our own deployment guide and has no built-in per-connection limiter, so for that setup the firewall rule is the control. I said so rather than inventing a directive.

The `max_connections_per_ip` row in `docs/configuration.md` now says where the cap applies and links to the new section.

## Verification

Docs only, no code change. The claims were checked against the source rather than from memory: the default of 10 (`src/config.zig`) and the 10s request timeout (`src/server.zig`). The cross-reference anchor resolves.
