### PR TITLE
Release the read transaction before replying to NEG-OPEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A failed storage read is no longer reported as a finished result set. An iterator error was swallowed as "no more events" on all three query paths, so REQ sent EOSE over a partial set, NEG-OPEN sealed and reconciled one (making the relay report events as missing that it actually holds), and COUNT answered with a number a failed read had lowered. Each now reports the failure instead (#172)
 - NEG-OPEN no longer holds an LMDB read transaction open while replying. Enumeration ran inside a transaction scoped to the whole function, so the reconciliation reply, a 128 KiB frame written to a client that may be slow to take it, went out with the transaction still live, and LMDB cannot reclaim a page freed after a transaction started for as long as it lives. Enumeration is now scoped so the transaction is released before anything is written. The error replies on this path were affected the same way (#172)
 
 - A REQ that ends early no longer reports success. `EOSE` tells a client it has the whole result set, and it was sent unconditionally, including after a write failure or a skipped event. Streaming now reports how it ended and `EOSE` is sent only on completion; a stream cut short ends with `CLOSED` and a reason, and the subscription is dropped first so the relay does not keep broadcasting to a subscription it just declared closed (#171)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- NEG-OPEN no longer holds an LMDB read transaction open while replying. Enumeration ran inside a transaction scoped to the whole function, so the reconciliation reply, a 128 KiB frame written to a client that may be slow to take it, went out with the transaction still live, and LMDB cannot reclaim a page freed after a transaction started for as long as it lives. Enumeration is now scoped so the transaction is released before anything is written. The error replies on this path were affected the same way (#172)
+
 - A REQ that ends early no longer reports success. `EOSE` tells a client it has the whole result set, and it was sent unconditionally, including after a write failure or a skipped event. Streaming now reports how it ended and `EOSE` is sent only on completion; a stream cut short ends with `CLOSED` and a reason, and the subscription is dropped first so the relay does not keep broadcasting to a subscription it just declared closed (#171)
 - Result streaming is bounded by a wall-clock budget as a backstop on how long a REQ can hold an LMDB read transaction open, which blocks free-page reclamation for its lifetime. Note the primary bound in the shipped build is that the socket is non-blocking, so a peer that stops reading fails its next write immediately; the budget matters if httpz is ever built in blocking mode. The earlier claim that `SO_SNDTIMEO` bounds these writes was wrong, and the misleading comment has been corrected (#171)
 

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -51,6 +51,11 @@ fn monotonicSeconds() i64 {
 /// completion, since EOSE tells the client it has the whole set.
 const StreamOutcome = enum { complete, write_failed, timed_out, incomplete };
 
+/// Result of enumerating the serving side of a negentropy session. Kept separate
+/// from the replies so the read transaction can be closed before any of them are
+/// written.
+const NegEnumeration = enum { ok, query_failed, too_many, truncated };
+
 // `conn` is generic so the budget path can be exercised without a live
 // socket: a real *Connection returns error.NotConnected when it has no
 // websocket, which would mask every outcome as .write_failed.
@@ -774,38 +779,56 @@ pub const Handler = struct {
         };
 
         if (self.shutdown.load(.acquire)) return;
-        // Serving-side enumeration uses the capped query() by design: this path is
-        // network-reachable, so reconciliation stays DoS-safe. If the scan cap
-        // truncates enumeration it is detected below and surfaced as NEG-ERR
-        // rather than silently under-enumerating.
-        var iter = self.store.query(&[_]nostr.Filter{filter}, self.config.negentropy_max_sync_events) catch {
-            conn.removeNegSession(sub_id);
-            self.sendNegErr(conn, sub_id, "error: query failed");
-            return;
-        };
-        defer iter.deinit();
 
-        var count: u32 = 0;
-        while (iter.next() catch null) |json| {
-            var event = nostr.Event.parse(json) catch continue;
-            defer event.deinit();
-            session.storage.insert(@intCast(event.createdAt()), event.id()) catch continue;
-            count += 1;
-            if (count >= self.config.negentropy_max_sync_events) {
+        // Enumerate inside a block so the LMDB read transaction is released
+        // before anything is written to the socket. LMDB cannot reclaim a page
+        // freed after the transaction started for as long as it lives, and every
+        // exit from here writes: the replies below, and reconcileAndSend, which
+        // builds a 128 KiB frame and hands it to a client that may be slow to
+        // take it. Nothing is sent until the transaction is gone.
+        const enumeration: NegEnumeration = blk: {
+            // Serving-side enumeration uses the capped query() by design: this
+            // path is network-reachable, so reconciliation stays DoS-safe. If the
+            // scan cap truncates enumeration it is detected below and surfaced as
+            // NEG-ERR rather than silently under-enumerating.
+            var iter = self.store.query(&[_]nostr.Filter{filter}, self.config.negentropy_max_sync_events) catch
+                break :blk .query_failed;
+            defer iter.deinit();
+
+            var count: u32 = 0;
+            while (iter.next() catch null) |json| {
+                var event = nostr.Event.parse(json) catch continue;
+                defer event.deinit();
+                session.storage.insert(@intCast(event.createdAt()), event.id()) catch continue;
+                count += 1;
+                if (count >= self.config.negentropy_max_sync_events) break :blk .too_many;
+            }
+
+            // The scan cap may stop enumeration before all matching stored events
+            // are seen. Sealing a partial set would make reconciliation report
+            // events as missing that the relay actually holds, so surface
+            // truncation as an error rather than silently sealing it.
+            if (iter.truncated) break :blk .truncated;
+            break :blk .ok;
+        };
+
+        switch (enumeration) {
+            .ok => {},
+            .query_failed => {
+                conn.removeNegSession(sub_id);
+                self.sendNegErr(conn, sub_id, "error: query failed");
+                return;
+            },
+            .too_many => {
                 conn.removeNegSession(sub_id);
                 self.sendNegErr(conn, sub_id, "blocked: too many events");
                 return;
-            }
-        }
-
-        // The scan cap may stop enumeration before all matching stored events are
-        // seen. Sealing a partial set would make reconciliation report events as
-        // missing that the relay actually holds, so surface truncation as an error
-        // rather than silently sealing an incomplete set.
-        if (iter.truncated) {
-            conn.removeNegSession(sub_id);
-            self.sendNegErr(conn, sub_id, "error: result set too large to reconcile");
-            return;
+            },
+            .truncated => {
+                conn.removeNegSession(sub_id);
+                self.sendNegErr(conn, sub_id, "error: result set too large to reconcile");
+                return;
+            },
         }
 
         session.storage.seal();

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -64,7 +64,13 @@ fn streamQueryResults(conn: anytype, sub_id: []const u8, iter: anytype, budget_s
     // budget by the size of the step, and a step forwards would trip it instantly
     // and cut every in-flight REQ short.
     const started = monotonicSeconds();
-    while (iter.next() catch null) |json| {
+    while (true) {
+        // An iterator error must not be swallowed as "no more events". Doing so
+        // ends the stream early and reports .complete, so the client is sent
+        // EOSE over a partial set: the same failure as the too-large event
+        // below, arriving by a different route.
+        const next = iter.next() catch return .incomplete;
+        const json = next orelse break;
         var buf: [65536]u8 = undefined;
         // An event that will not fit the frame buffer cannot be delivered.
         // Skipping it silently and then reporting .complete would tell the client
@@ -651,6 +657,7 @@ pub const Handler = struct {
         }
 
         var total_count: u64 = 0;
+        var read_failed = false;
         for (filters) |filter| {
             // Uses the capped query() intentionally: for a selective filter this
             // count is approximate (bounded by the scan cap) rather than exact,
@@ -661,9 +668,25 @@ pub const Handler = struct {
             };
             defer iter.deinit();
 
-            while (iter.next() catch null) |_| {
+            while (true) {
+                // A read error would otherwise silently lower the reported count.
+                // COUNT being approximate is a documented property of the scan
+                // cap, not licence to report a number a failed read invented.
+                // Flagged rather than answered here so the reply goes out after
+                // the deferred deinit has released the read transaction.
+                const next = iter.next() catch {
+                    read_failed = true;
+                    break;
+                };
+                if (next == null) break;
                 total_count += 1;
             }
+            if (read_failed) break;
+        }
+
+        if (read_failed) {
+            self.sendClosed(conn, sub_id, "error: query failed");
+            return;
         }
 
         self.sendCount(conn, sub_id, total_count);
@@ -796,7 +819,13 @@ pub const Handler = struct {
             defer iter.deinit();
 
             var count: u32 = 0;
-            while (iter.next() catch null) |json| {
+            while (true) {
+                // Sealing a partial set makes reconciliation report events as
+                // missing that the relay actually holds, which is exactly what
+                // the truncation check below exists to prevent. An iterator
+                // error has to be surfaced for the same reason.
+                const next = iter.next() catch break :blk .query_failed;
+                const json = next orelse break;
                 var event = nostr.Event.parse(json) catch continue;
                 defer event.deinit();
                 session.storage.insert(@intCast(event.createdAt()), event.id()) catch continue;
@@ -1095,10 +1124,16 @@ const StubConn = struct {
 
 const StubIter = struct {
     remaining: usize,
+    fail_after: ?usize = null,
+    yielded: usize = 0,
 
     fn next(self: *StubIter) !?[]const u8 {
+        if (self.fail_after) |n| {
+            if (self.yielded >= n) return error.ReadFailed;
+        }
         if (self.remaining == 0) return null;
         self.remaining -= 1;
+        self.yielded += 1;
         return "{\"id\":\"x\"}";
     }
 };
@@ -1127,6 +1162,18 @@ test "streamQueryResults: a dead peer stops the stream without draining it" {
     try testing.expectEqual(StreamOutcome.write_failed, streamQueryResults(&conn, "s", &iter, 3600));
     try testing.expectEqual(@as(usize, 2), conn.written);
     try testing.expect(iter.remaining > 90);
+}
+
+test "streamQueryResults: a failing iterator is not reported as a finished set" {
+    // An iterator error used to be swallowed as "no more events", which ended
+    // the stream and reported .complete, so the client got EOSE over a partial
+    // result set.
+    var conn = StubConn{};
+    var iter = StubIter{ .remaining = 100, .fail_after = 3 };
+    const outcome = streamQueryResults(&conn, "s", &iter, 3600);
+    try testing.expectEqual(StreamOutcome.incomplete, outcome);
+    try testing.expect(outcome != .complete);
+    try testing.expectEqual(@as(usize, 3), conn.written);
 }
 
 test "streamQueryResults: a client slower than the budget is cut off, not silently truncated" {


### PR DESCRIPTION
`handleNegOpen` opened its iterator with a **function-scoped** `defer iter.deinit()`, so the LMDB read transaction stayed live until the function returned. Every exit from it wrote under that transaction, including `reconcileAndSend`, which builds a 128 KiB frame and hands it to a client that may be slow to take it.

LMDB cannot reclaim a page freed after a transaction started for as long as that transaction lives, so this held free-page reclamation open for the duration of a network write to an arbitrary peer.

This is the path #171 was actually looking for. Notably `handleReq` scopes its iterators inside blocks and `handleCount` puts the `defer` inside the loop body, so both already release before writing — NEG-OPEN was the one that did not.

## Change

Enumeration now runs inside a block that yields an outcome, and every reply is sent after that block. Nothing is written while the transaction is open.

Behavior is otherwise unchanged: the same four cases produce the same NEG-ERR messages, in the same order, with the same session cleanup.

## Verification

The NIP-77 integration test drives this handler end to end, replicating events between two live relays via negentropy reconciliation. Built `noz` at the commit CI pins and ran it locally against two wisp instances:

```
ok   - relay A seeded
ok   - relay B empty before sync
ok   - NIP-77 negentropy replicated A into B
3 passed, 0 failed
```

61/61 unit tests.

## Not addressed here

Two things found while tracing this, deliberately left out because they are larger and belong on their own:

- The enumeration itself is unbounded relative to any budget: `negentropy_max_sync_events` defaults to 1,000,000, giving a scan cap of `limit × query_scan_multiplier` = 20,000,000 index entries, unauthenticated by default, all inside the one transaction. Scoping stops the *write* happening under it; it does not shorten the enumeration.
- `VectorStorage.insert` in libnostr-z does a sorted insert (`lowerBound` + `items.insert`), which is an O(n) memmove per element, and the query walks newest-first so every item lands at index 0 and shifts the whole array. That is O(n²). It is also **redundant**: `seal()` already does a full `std.mem.sort`, so appending and letting `seal` sort would give the same result in O(n log n). That fix belongs in libnostr-z, filed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NEG-OPEN response handling by releasing read transactions before sending reconciliation or error responses.
  * Prevented slow connections from unnecessarily prolonging transaction lifetimes.
  * Added clearer handling for query failures, event-limit overflow, and truncated scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->