### PR TITLE
Reject IP list entries that can never match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An `ip_whitelist`, `ip_blacklist` or `trusted_proxies` entry that can never match is now rejected at load with a warning naming it, instead of being stored and silently matching nothing. CIDR (`10.0.0.0/8`) and globs (`192.168.*`) are the usual way this happened: both look correct, neither is supported, and on a deny list the result was fail-open, with the operator believing a range was blocked when it was not. On `trusted_proxies` it failed the other way, collapsing every client behind the proxy into one rate-limit bucket (#173)
+
 - A failed storage read is no longer reported as a finished result set. An iterator error was swallowed as "no more events" on all three query paths, so REQ sent EOSE over a partial set, NEG-OPEN sealed and reconciled one (making the relay report events as missing that it actually holds), and COUNT answered with a number a failed read had lowered. Each now reports the failure instead (#172)
 - NEG-OPEN no longer holds an LMDB read transaction open while replying. Enumeration ran inside a transaction scoped to the whole function, so the reconciliation reply, a 128 KiB frame written to a client that may be slow to take it, went out with the transaction still live, and LMDB cannot reclaim a page freed after a transaction started for as long as it lives. Enumeration is now scoped so the transaction is released before anything is written. The error replies on this path were affected the same way (#172)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,7 +186,9 @@ instead leave it stopped.
 | `ip_blacklist` | `WISP_IP_BLACKLIST` | csv | (empty) | These IPs/prefixes are refused. |
 
 IP list entries match exactly unless they end in `.` (IPv4 prefix) or `:` (IPv6 prefix), e.g.
-`10.0.0.` matches `10.0.0.0`–`10.0.0.255`. CIDR notation and `*` wildcards are not supported.
+`10.0.0.` matches `10.0.0.0`–`10.0.0.255`. CIDR notation and `*` wildcards are not supported: an
+entry like `10.0.0.0/8` or `192.168.*` is rejected at startup with a warning naming it, rather
+than being accepted and then matching nothing. The same applies to `trusted_proxies`.
 
 ### `[spider]`
 

--- a/src/rate_limiter.zig
+++ b/src/rate_limiter.zig
@@ -1,6 +1,39 @@
 const std = @import("std");
 const nostr = @import("nostr.zig");
 
+const log = std.log.scoped(.ip_filter);
+
+/// Can this entry ever match a client address?
+///
+/// Entries are compared as text: exactly, or as a prefix when they end in '.'
+/// or ':'. An entry that is neither a valid address nor a valid prefix is
+/// accepted at load and then never matches anything, which for a blocklist
+/// means an operator believes a range is blocked when it is not. CIDR
+/// ("10.0.0.0/8") and globs ("192.168.*") are the usual way this happens, since
+/// both look right and neither is supported.
+fn safeEntry(entry: []const u8, buf: *[64]u8) []const u8 {
+    const len = @min(entry.len, buf.len);
+    for (entry[0..len], buf[0..len]) |c, *out| {
+        out.* = if (std.ascii.isPrint(c)) c else '?';
+    }
+    return buf[0..len];
+}
+
+fn entryCanMatch(entry: []const u8) bool {
+    if (entry.len == 0) return false;
+    const last = entry[entry.len - 1];
+    if (last == '.' or last == ':') {
+        if (entry.len < 2) return false;
+        for (entry) |c| switch (c) {
+            '0'...'9', 'a'...'f', 'A'...'F', '.', ':' => {},
+            else => return false,
+        };
+        return true;
+    }
+    _ = std.Io.net.IpAddress.parse(entry, 0) catch return false;
+    return true;
+}
+
 // Per-IP limiter state is sharded across independent mutex+map buckets so
 // worker threads keying on different IPs do not serialize on one process-global
 // lock on every event/query/connection. The shard is chosen by hashing the
@@ -246,37 +279,40 @@ pub const IpFilter = struct {
     }
 
     pub fn loadWhitelist(self: *IpFilter, list: []const u8) !void {
-        const io = nostr.io.io();
-        self.mutex.lockUncancelable(io);
-        defer self.mutex.unlock(io);
-
-        if (list.len == 0) return;
-
-        self.whitelist_enabled = true;
-        var iter = std.mem.splitScalar(u8, list, ',');
-        while (iter.next()) |entry| {
-            const trimmed = std.mem.trim(u8, entry, " \t");
-            if (trimmed.len > 0) {
-                const copy = try self.allocator.dupe(u8, trimmed);
-                try self.whitelist.put(copy, {});
-            }
-        }
+        return self.loadInto(&self.whitelist, list, "allow list", true);
     }
 
     pub fn loadBlacklist(self: *IpFilter, list: []const u8) !void {
+        return self.loadInto(&self.blacklist, list, "deny list", false);
+    }
+
+    fn loadInto(
+        self: *IpFilter,
+        map: *std.StringHashMap(void),
+        list: []const u8,
+        name: []const u8,
+        enables_whitelist: bool,
+    ) !void {
         const io = nostr.io.io();
         self.mutex.lockUncancelable(io);
         defer self.mutex.unlock(io);
 
         if (list.len == 0) return;
 
+        if (enables_whitelist) self.whitelist_enabled = true;
         var iter = std.mem.splitScalar(u8, list, ',');
         while (iter.next()) |entry| {
             const trimmed = std.mem.trim(u8, entry, " \t");
-            if (trimmed.len > 0) {
-                const copy = try self.allocator.dupe(u8, trimmed);
-                try self.blacklist.put(copy, {});
+            if (trimmed.len == 0) continue;
+            // Refusing the entry and saying so beats storing one that quietly
+            // never matches: the operator can act on a log line, not on silence.
+            if (!entryCanMatch(trimmed)) {
+                var buf: [64]u8 = undefined;
+                log.warn("{s} entry \"{s}\" can never match and was ignored: entries are an exact address or a prefix ending in '.' or ':'; CIDR and '*' are not supported", .{ name, safeEntry(trimmed, &buf) });
+                continue;
             }
+            const copy = try self.allocator.dupe(u8, trimmed);
+            try map.put(copy, {});
         }
     }
 
@@ -669,4 +705,42 @@ test "EventRateLimiter cleanup reclaims only idle buckets" {
     limiter.cleanupAt(1060);
     try std.testing.expectEqual(@as(usize, 1), limiter.trackedCount());
     try std.testing.expect(limiter.tracks("2.2.2.2"));
+}
+
+test entryCanMatch {
+    // Exact addresses.
+    try std.testing.expect(entryCanMatch("10.0.0.5"));
+    try std.testing.expect(entryCanMatch("::1"));
+    try std.testing.expect(entryCanMatch("2001:db8::1"));
+
+    // Prefix forms, which must end at an octet or group boundary.
+    try std.testing.expect(entryCanMatch("10.0.0."));
+    try std.testing.expect(entryCanMatch("192.168."));
+    try std.testing.expect(entryCanMatch("2001:db8:"));
+
+    // The two ways operators actually get this wrong. Both look correct and
+    // neither is supported, so before this they were stored and silently never
+    // matched, leaving a deny list open.
+    try std.testing.expect(!entryCanMatch("10.0.0.0/8"));
+    try std.testing.expect(!entryCanMatch("192.168.*"));
+    try std.testing.expect(!entryCanMatch("0.0.0.0/0"));
+
+    // Other junk that can never match an address.
+    try std.testing.expect(!entryCanMatch(""));
+    try std.testing.expect(!entryCanMatch("."));
+    try std.testing.expect(!entryCanMatch(":"));
+    try std.testing.expect(!entryCanMatch("example.com"));
+    try std.testing.expect(!entryCanMatch("10.0.0.256"));
+}
+
+test "loadBlacklist: an entry that can never match is not stored" {
+    var f = IpFilter.init(std.testing.allocator);
+    defer f.deinit();
+
+    // A CIDR entry alongside a usable one: the usable one still works, and the
+    // CIDR is dropped rather than sitting in the map pretending to block.
+    try f.loadBlacklist("10.0.0.0/8, 1.2.3.4");
+    try std.testing.expect(!f.isAllowed("1.2.3.4"));
+    // Nothing in 10.x is actually blocked, which is the point of the warning.
+    try std.testing.expect(f.isAllowed("10.1.2.3"));
 }


### PR DESCRIPTION
`ip_whitelist`, `ip_blacklist` and `trusted_proxies` entries were stored verbatim after a whitespace trim. Matching is textual: exact, or a prefix when the entry ends in `.` or `:`. An entry in any other shape is therefore accepted at load and then **never matches anything**.

CIDR and globs are how this happens in practice, because both look correct and neither is supported:

- On a **deny list**, `10.0.0.0/8` or `192.168.*` left it **fail-open**. The operator believes a range is blocked; nothing is.
- On **`trusted_proxies`**, it fails the other way. The entry never matches, forwarded headers are ignored, and every client behind the proxy collapses into a single rate-limit bucket keyed on the proxy address, so the per-IP limits stop isolating anyone.

## Change

Entries are validated at load: an exact entry must parse as an address, a prefix entry must look like one, and anything else is dropped with a warning naming the list and the entry. The value is scrubbed before logging, matching the handling added in #170.

The two loaders had drifted into near-copies; they are now one function differing only in which map it fills and whether it arms the allow list.

## Verification

Against a running relay with all three lists misconfigured:

```
warning(ip_filter): deny list entry "10.0.0.0/8" can never match and was ignored: entries are an exact address or a prefix ending in '.' or ':'; CIDR and '*' are not supported
warning(ip_filter): deny list entry "192.168.*" can never match and was ignored: ...
warning(ip_filter): allow list entry "172.16.0.0/12" can never match and was ignored: ...
```

The `trusted_proxies` warning confirms the shared loader covers that list too, which is the part the original issue did not mention.

Unit tests cover the accepted forms (exact v4/v6, v4/v6 prefixes), the two realistic mistakes, and junk like `example.com` and `10.0.0.256`. One test asserts the behavior that matters: with `"10.0.0.0/8, 1.2.3.4"`, the usable entry still blocks and `10.1.2.3` is still allowed, which is the fail-open being made visible rather than silently fixed.

64/64 tests, up from 62.

## Note

This validates shape, not intent. `10.0.0.` is accepted and blocks `10.0.0.0`–`10.0.0.255`; an operator who meant `10.0.0.0/8` and writes `10.0.0.` still gets a narrower range than they wanted. Supporting CIDR properly is a separate feature, not something to smuggle in here.
