### PR TITLE
Reconcile a negentropy set that is exactly at the cap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,29 @@ jobs:
           stop "$a"; stop "$b"; wait 2>/dev/null
           exit $rc
 
+      - name: Run NIP-77 boundary test (match set exactly at the cap)
+        run: |
+          stop() {
+            kill "$1" 2>/dev/null || return 0
+            for i in $(seq 1 20); do kill -0 "$1" 2>/dev/null || return 0; sleep 0.25; done
+            kill -9 "$1" 2>/dev/null || true
+          }
+          # A low cap so the boundary is cheap to hit; the relays must agree on it.
+          start() { # port datadir -> echoes pid, returns 1 if never ready
+            nohup env WISP_HOST=127.0.0.1 WISP_PORT="$1" WISP_STORAGE_PATH="$2" \
+              WISP_NEGENTROPY_MAX_SYNC_EVENTS=5 \
+              ./zig-out/bin/wisp relay > "relay-$1.log" 2>&1 &
+            local pid=$!
+            for i in $(seq 1 40); do nc -z 127.0.0.1 "$1" && { echo "$pid"; return 0; }; sleep 0.25; done
+            echo "$pid"; return 1
+          }
+          a=$(start 7783 "$RUNNER_TEMP/wisp-negb-a") || { echo "relay 7783 not ready"; stop "$a"; exit 1; }
+          b=$(start 7784 "$RUNNER_TEMP/wisp-negb-b") || { echo "relay 7784 not ready"; stop "$a"; stop "$b"; exit 1; }
+          bash tests/integration_negentropy_boundary.sh ws://127.0.0.1:7783 ws://127.0.0.1:7784 5
+          rc=$?
+          stop "$a"; stop "$b"; wait 2>/dev/null
+          exit $rc
+
       - name: Run NIP-86 management test
         run: |
           stop() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A negentropy match set of exactly `negentropy_max_sync_events` is no longer rejected as too large. The serving side asked the store for exactly the cap, and the iterator stops once it has returned that many events, so a complete set at the cap was indistinguishable from one exceeding it and got `NEG-ERR blocked: too many events`. It now asks for one more event, which is what tells the two apart (#174)
+
 - An `ip_whitelist`, `ip_blacklist` or `trusted_proxies` entry that can never match is now rejected at load with a warning naming it, instead of being stored and silently matching nothing. CIDR (`10.0.0.0/8`) and globs (`192.168.*`) are the usual way this happened: both look correct, neither is supported, and on a deny list the result was fail-open, with the operator believing a range was blocked when it was not. On `trusted_proxies` it failed the other way, collapsing every client behind the proxy into one rate-limit bucket (#173)
 
 - A failed storage read is no longer reported as a finished result set. An iterator error was swallowed as "no more events" on all three query paths, so REQ sent EOSE over a partial set, NEG-OPEN sealed and reconciled one (making the relay report events as missing that it actually holds), and COUNT answered with a number a failed read had lowered. Each now reports the failure instead (#172)

--- a/src/handler.zig
+++ b/src/handler.zig
@@ -814,7 +814,13 @@ pub const Handler = struct {
             // path is network-reachable, so reconciliation stays DoS-safe. If the
             // scan cap truncates enumeration it is detected below and surfaced as
             // NEG-ERR rather than silently under-enumerating.
-            var iter = self.store.query(&[_]nostr.Filter{filter}, self.config.negentropy_max_sync_events) catch
+            // Ask for one more than the cap. The iterator stops once it has
+            // returned `limit` events, so querying for exactly the cap makes a
+            // set of exactly negentropy_max_sync_events indistinguishable from
+            // one that exceeds it, and the complete set is rejected. Seeing the
+            // extra event is the only way to tell "at the cap" from "over" it.
+            const enumeration_limit = self.config.negentropy_max_sync_events +| 1;
+            var iter = self.store.query(&[_]nostr.Filter{filter}, enumeration_limit) catch
                 break :blk .query_failed;
             defer iter.deinit();
 
@@ -830,7 +836,9 @@ pub const Handler = struct {
                 defer event.deinit();
                 session.storage.insert(@intCast(event.createdAt()), event.id()) catch continue;
                 count += 1;
-                if (count >= self.config.negentropy_max_sync_events) break :blk .too_many;
+                // Strictly greater: reaching the cap exactly is a set the relay
+                // can reconcile, only exceeding it is not.
+                if (count > self.config.negentropy_max_sync_events) break :blk .too_many;
             }
 
             // The scan cap may stop enumeration before all matching stored events

--- a/tests/integration_negentropy_boundary.sh
+++ b/tests/integration_negentropy_boundary.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# NIP-77 boundary test: a match set of EXACTLY negentropy_max_sync_events must
+# reconcile, not be rejected.
+#
+# The serving side enumerates through the capped query(). If it asks for exactly
+# the cap, the iterator stops once it has returned that many events, so a
+# complete set of exactly the cap is indistinguishable from one that exceeds it,
+# and the relay answers NEG-ERR "blocked: too many events" for a set it could
+# have served. Asking for one more event is what separates the two cases.
+#
+# Both relays must run with WISP_NEGENTROPY_MAX_SYNC_EVENTS set to <cap>.
+#
+# Usage: tests/integration_negentropy_boundary.sh <relay-a-url> <relay-b-url> <cap>
+# Requires: noz on PATH. Exits non-zero if any assertion fails.
+set -u
+A="${1:?relay A url required}"
+B="${2:?relay B url required}"
+CAP="${3:?cap required}"
+SEC1=0000000000000000000000000000000000000000000000000000000000000001
+
+pass=0
+fail=0
+chk() { # desc expected actual
+  if [ "$2" = "$3" ]; then
+    echo "ok   - $1"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - $1 (expected '$2', got '$3')"
+    fail=$((fail + 1))
+  fi
+}
+count() { timeout 10 noz req -k 1 -l $((CAP * 4)) "$1" 2>/dev/null | grep -c '"kind"'; }
+
+# Exactly CAP events, distinct created_at so each is unique. Not one under, not
+# one over: the boundary is the whole point.
+for i in $(seq 1 "$CAP"); do
+  timeout 6 noz event --sec $SEC1 --ts $((1700000000 + i)) -c "bound$i" "$A" >/dev/null 2>&1
+done
+sleep 1
+
+chk "relay A holds exactly the cap" "$CAP" "$(count "$A")"
+chk "relay B empty before sync" 0 "$(count "$B")"
+
+# The client does not surface the relay's NEG-ERR text, so asserting on the
+# message would pass whether or not the bug is present. What the bug actually
+# does is prevent replication, so that is what is asserted: with the off-by-one
+# the relay answers NEG-ERR, nothing reconciles, and B ends up empty.
+timeout 40 noz sync "$A" "$B" -k 1 >/dev/null 2>&1
+sleep 1
+
+chk "set of exactly the cap reconciled into B" "$CAP" "$(count "$B")"
+
+echo "-----"
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
The serving side asked the store for exactly `negentropy_max_sync_events`, and the iterator stops once it has returned that many events (`store.zig`: `if (self.returned >= self.limit) return null`).

So a **complete** set of exactly the cap and a set that **exceeds** it are indistinguishable from the count alone, and the complete one was rejected with `NEG-ERR blocked: too many events` — after the relay had already enumerated all of it, and when the next call would have returned null anyway.

Asking for one more event is what separates the two, and the check becomes strictly greater: reaching the cap is a set the relay can serve, only exceeding it is not.

This is the same shape as the scan-cap boundary fix (`wisp-oj5`), one level up. That one peeked at the next entry rather than trusting the cap; this one asks for the extra event for the same reason.

## Verification

New integration test seeds exactly the cap and asserts the set replicates. Wired into CI with `WISP_NEGENTROPY_MAX_SYNC_EVENTS=5` so the boundary is cheap to hit.

Run against **both** builds rather than trusting a green test:

- On the fix: `4 passed, 0 failed`
- On the unfixed code: `FAIL - set of exactly the cap reconciled into B (expected '5', got '0')`

One note on the test itself. My first version also asserted the relay did not answer `"too many events"`, by grepping the sync client's output. That check **passed on the broken build too**, because the client does not surface the relay's NEG-ERR text — so it was assurance that could never fail. I removed it rather than leave it in looking like coverage. What the bug actually does is prevent replication, so that is what is asserted.

64/64 unit tests unchanged.
