### PR TITLE
Close a connection whose write failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A connection whose write fails is now closed instead of left in place. The WebSocket write path drains its buffer as it goes and only reports the error afterwards, so a write that fails partway has already put a truncated frame on the wire; callers cannot tell how much went out, and every one of them skipped past the failure, so the next message written to that connection was appended into a desynchronized frame stream and the client saw garbage from then on (#175)
+
 - A negentropy match set of exactly `negentropy_max_sync_events` is no longer rejected as too large. The serving side asked the store for exactly the cap, and the iterator stops once it has returned that many events, so a complete set at the cap was indistinguishable from one exceeding it and got `NEG-ERR blocked: too many events`. It now asks for one more event, which is what tells the two apart (#174)
 
 - An `ip_whitelist`, `ip_blacklist` or `trusted_proxies` entry that can never match is now rejected at load with a warning naming it, instead of being stored and silently matching nothing. CIDR (`10.0.0.0/8`) and globs (`192.168.*`) are the usual way this happened: both look correct, neither is supported, and on a deny list the result was fail-open, with the operator believing a range was blocked when it was not. On `trusted_proxies` it failed the other way, collapsing every client behind the proxy into one rate-limit bucket (#173)

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -94,7 +94,22 @@ pub const Connection = struct {
     /// the write times out, which callers use to stop streaming.
     pub fn write(self: *Connection, data: []const u8) !void {
         const conn = self.ws_conn orelse return error.NotConnected;
-        return conn.write(data);
+        conn.write(data) catch |err| {
+            // A write that fails partway leaves a truncated frame on the wire:
+            // the library drains its iovec as it goes and only surfaces the error
+            // afterwards, so bytes are already gone. Callers cannot tell how much
+            // was written, and every one of them treats a failed write as
+            // something to skip, so without this the next message written to this
+            // connection is appended into a desynchronized frame stream and the
+            // client sees garbage from then on.
+            //
+            // Disconnecting is the honest outcome: a peer that cannot accept a
+            // frame is not receiving the subscription anyway, and it can
+            // reconnect. Shutting the read half down lets the epoll worker run
+            // its normal cleanup rather than closing the fd underneath it.
+            self.closeWs();
+            return err;
+        };
     }
 
     /// Request the connection be closed (e.g. idle timeout). Safe to call from


### PR DESCRIPTION
`websocket.zig`'s `writeAllIOVec` drains its iovec as it goes and only surfaces the error afterwards, so a write that fails partway **has already put bytes on the wire**. The frame is truncated.

Callers cannot tell how much went out, and every one of them treats a failed write as something to skip (`catch {}`, or a `.write_failed` return that does nothing). So the next message written to that connection — a broadcast EVENT, an OK, a NOTICE — is appended into a desynchronized frame stream. From the client's point of view everything after that is garbage.

This is easy to reach now that the WebSocket fd is confirmed non-blocking (measured in #171): a client that stops reading fills the send buffer and the next write fails immediately.

## Where the fix goes

In `Connection.write`, not at the call sites. No caller has the information needed to decide, because the error does not say whether anything was written. Centralizing also makes the invariant unconditional: a failed write always closes.

It shuts down the read half rather than closing the fd, so the epoll worker's cleanup path stays in charge — that is what reclaims the connection slot and the per-IP limiter bucket.

## Tradeoff

A peer that cannot accept a frame is disconnected rather than silently skipped. That is a real behavior change, and it is the right one: such a peer is not receiving its subscription anyway, and it can reconnect. The alternative is what we have today, where the client stays connected and receives a corrupt stream indefinitely.

## Verification

This touches every write in the relay, so unit tests are not the interesting signal. Ran the integration suites locally:

- Protocol suite: **45 passed, 0 failed**
- WS idle slot-reclaim: **6 passed, 0 failed**

The second is the one that matters here: it is the black-box guard for the connection-lifecycle path, asserting that a server-initiated close reclaims both the connection slot and the limiter bucket, read back off `/metrics`. Closing on a path that previously did not close is exactly the kind of change that could leak a slot, and it does not.

Worth noting my first run of that test reported a failure, which turned out to be my mistake rather than the code's: the test documents that it must run with `WISP_IDLE_SECONDS=1 WISP_MAX_CONNECTIONS_PER_IP=2` and I had started the relay with defaults. Re-run with the documented environment it passes 6/6.

64/64 unit tests.
