### PR TITLE
Remove the spider's closeClient no-op and its unread client pointer

### DIFF
--- a/src/spider.zig
+++ b/src/spider.zig
@@ -126,10 +126,20 @@ pub const Spider = struct {
         log.info("Spider stopping...", .{});
         self.running.store(false, .release);
 
-        for (self.relays.values()) |*conn| {
-            conn.closeClient();
-        }
-
+        // Threads are stopped by the running flag, not by interrupting their
+        // sockets. After a relay is connected they check shouldRun() around every
+        // step and read with a 1s timeout, so they observe the flag within about
+        // a second. A thread still inside websocket.Client.init is the exception:
+        // connect, TLS and the handshake are each bounded to 10s upstream, and
+        // DNS resolution is not bounded at all, so a stop racing a connection
+        // attempt can wait that long before the thread returns.
+        //
+        // There used to be a closeClient() call here that did nothing, backed by
+        // an active_client pointer that was stored and cleared but never read.
+        // Both are gone: an interrupt that does not interrupt is worse than none,
+        // because it makes this loop look like it bounds the join when it does
+        // not. Interrupting the connect window needs the socket from inside
+        // init(), which is exactly what is not available until init() returns.
         for (self.threads.items) |thread| {
             thread.join();
         }
@@ -411,9 +421,6 @@ pub const Spider = struct {
             log.err("{s}: Host too long", .{relay_url});
             return false;
         };
-
-        conn.active_client = &client;
-        defer conn.active_client = null;
 
         client.handshake(parsed.path, .{
             .headers = host_header,
@@ -1021,7 +1028,6 @@ const RelayConn = struct {
     rate_limit_until: i64 = 0,
     rate_limit_backoff_ms: u64 = RATE_LIMIT_BACKOFF_MS,
     negentropy_supported: bool = true,
-    active_client: ?*websocket.Client = null,
     // Newly-stored events across the entire most recent session (negentropy
     // first-sync, catch-up, and the live read loop combined). A session that
     // delivered events counts as productive even if it was short, so the
@@ -1033,10 +1039,6 @@ const RelayConn = struct {
 
     fn init(url: []const u8) RelayConn {
         return .{ .url = url };
-    }
-
-    fn closeClient(self: *RelayConn) void {
-        _ = self;
     }
 
     fn applyRateLimit(self: *RelayConn) void {


### PR DESCRIPTION
`stop()` called `closeClient()` on every relay. `closeClient()` was `_ = self;`. The `active_client` pointer it was presumably meant to use was assigned and cleared but **never read anywhere**.

An interrupt that does not interrupt is worse than none: the loop in `stop()` reads as though it bounds the `join()` that follows, and it does not. The pointer was also a hazard in waiting, since it published the address of a **stack local** across threads for a future implementation to pick up.

## Why not implement it instead

The issue suggested making `closeClient` shut down the in-flight socket, publishing the fd rather than a stack pointer. I traced what that would actually buy, and it is nothing:

`active_client` is set **after** `websocket.Client.init` returns, and `init` is where the blocking happens. Interrupting that window needs the socket from inside `init`, which is precisely what is unavailable until it returns.

And the window it *could* have covered is already responsive. Once connected, threads check `shouldRun()` around every step (10 call sites) and read with `readTimeout(1000)`, so they observe the stop flag within about a second. There is no long blocking read to interrupt.

So the honest resolution is to delete the dead affordance and record the real behavior, rather than build machinery that addresses a window that is already fast and cannot address the one that is slow.

## What `stop()` says now

Threads are stopped by the running flag; connected threads observe it within ~1s. A thread still inside `init` waits out connect, TLS and handshake, each bounded to 10s upstream, plus DNS resolution which is not bounded at all. That residual is real and is now written down instead of being papered over by a no-op.

## Verification

- Spider integration test: **3 passed, 0 failed** (seeding, NIP-77 sync, live subscription).
- SIGINT to a spider-enabled relay: exits in **1021ms**, which matches the 1s read timeout the comment describes. That is the claim being measured rather than asserted.
- 64/64 unit tests.
