### PR TITLE
Guard the multi-filter ids fast-path gate with a test

### DIFF
--- a/src/store.zig
+++ b/src/store.zig
@@ -937,6 +937,64 @@ test "ids fast-path returns newest matches first under limit" {
     try testing.expectEqual(base + 3, prev);
 }
 
+test "a multi-filter REQ is not narrowed to the ids in filters[0]" {
+    // Guards the filters.len == 1 gate on the ids fast path. Without it a REQ
+    // whose first filter carries ids answers from that id list alone and the
+    // other filters are dropped, so a client asking for "these two ids OR
+    // everything by this author" silently loses the author half. Nothing
+    // exercised this before, so removing the gate passed CI.
+    const alloc = testing.allocator;
+    const io = nostr.io.io();
+    const dir = "./.test-ids-multifilter";
+    std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, dir) catch {};
+
+    var lmdb = try Lmdb.init(alloc, dir ++ "/db.mdb", 256, .none);
+    defer lmdb.deinit();
+    var s = try Store.init(alloc, &lmdb);
+    defer s.deinit();
+
+    const base = nostr.io.timestamp() - 100000;
+    const pk_ids = "aa" ** 32;
+    const pk_other = "bb" ** 32;
+
+    // Two events addressed by id, and one that only the second filter can reach.
+    var ids: [2][32]u8 = undefined;
+    var i: u32 = 0;
+    while (i < 2) : (i += 1) {
+        var idb: [64]u8 = undefined;
+        testIdHex(i + 1, &idb);
+        try storeTestEvent(&s, alloc, &idb, pk_ids, base + @as(i64, i));
+        _ = try std.fmt.hexToBytes(&ids[i], &idb);
+    }
+    var other_id: [64]u8 = undefined;
+    testIdHex(99, &other_id);
+    try storeTestEvent(&s, alloc, &other_id, pk_other, base + 50);
+
+    var authors: [1][32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&authors[0], pk_other);
+    const filters = [_]nostr.Filter{
+        .{ .ids_bytes = &ids },
+        .{ .authors_bytes = &authors },
+    };
+
+    var iter = try s.query(&filters, 100);
+    defer iter.deinit();
+
+    var saw_other = false;
+    var count: u32 = 0;
+    while (try iter.next()) |json| {
+        var ev = try nostr.Event.parse(json);
+        defer ev.deinit();
+        if (std.mem.eql(u8, &ev.pubkey_bytes, &authors[0])) saw_other = true;
+        count += 1;
+    }
+
+    // The union of both filters is all three events; the ids-only answer is two.
+    try testing.expect(saw_other);
+    try testing.expectEqual(@as(u32, 3), count);
+}
+
 test "queryFull and ids fast-path bypass the scan cap for old matches" {
     const alloc = testing.allocator;
     const io = nostr.io.io();


### PR DESCRIPTION
Closes the more important of the two test gaps named in the scan-cap issue.

## The gap

`store.zig` gates the ids fast path on `filters.len == 1`. That gate is what stops a REQ whose first filter carries `ids` from being answered out of that id list alone, silently dropping every other filter — a client asking for "these two ids OR everything by this author" would lose the author half.

Nothing exercised it. The fix was in the tree with nothing holding it there, so a refactor that dropped the gate would have passed CI.

## The test

Stores two events reachable only by id and one reachable only by the second filter's author, queries with both filters, and asserts the union of three comes back rather than the ids-only two.

**Verified it does what it is for**, since a test for a guard is worthless if it passes without the guard: changing the gate to `filters.len >= 1` fails it, and it passes with the gate restored.

65/65 tests.

## The other gap, deliberately not closed

The issue also names the NEG-ERR truncation path. I looked at what testing it would actually add and it is thin:

- Both directions of `iter.truncated` are already covered at the store level (`store.zig:855` positive, `:891` negative).
- What remains untested is the three-line handler branch that turns that flag into a NEG-ERR.
- Reaching it end to end needs a filter shaped to truncate the scan while matches remain, driven through a sync client that does not expose tag filters.

So it is meaningful effort to cover a trivial branch whose input is already tested, versus the gate above where a regression was genuinely invisible. I left it open on the issue with that reasoning rather than quietly marking the issue done.
