### PR TITLE
Bump libnostr-z for the linear negentropy storage load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped libnostr-z past v0.3.6 to pick up a negentropy storage fix. Loading records into a reconciliation session was O(n^2), because each insert moved every element after it and wisp enumerates a newest-first index, so every record landed at the front and shifted the whole array. Serving a NEG-OPEN over a large match set spent that time on a handler thread while the peer waited (#178)
+
 ### Added
 
 - `/metrics` now also exposes httpz's own counters. `httpz_connections` counts accepted TCP connections before any handler runs, so reading it against `wisp_connections_total` (completed WebSocket upgrades) distinguishes an accept loop that is running while work backs up from one that is stuck (#168)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,9 +13,16 @@
             .url = "https://github.com/karlseguin/websocket.zig/archive/b70e733bc0d0ba0a98ff5fe5ef64d3017c85f369.tar.gz",
             .hash = "websocket-0.1.0-ZPISdUoQBQC7zw1uSwbOEYdxZiTxNN4nf9RlWBsN0_Nd",
         },
+        // Pinned past v0.3.6 by commit for the negentropy storage fix: loading
+        // records used to be O(n^2) because each insert moved every element
+        // after it, and wisp enumerates a newest-first index, so every record
+        // landed at index 0 and shifted the whole array. Serving NEG-OPEN over a
+        // large match set spent that time on a handler thread. The manifest
+        // still says 0.3.6 because that is the version in the dependency's own
+        // build.zig.zon; the digest is what identifies the content.
         .nostr = .{
-            .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.6.tar.gz",
-            .hash = "nostr-0.3.6-JY6OcLPKDwAP8UJz5qRAVc4LKg3AB2zE7Eok-gky9o4d",
+            .url = "https://github.com/privkeyio/libnostr-z/archive/9a4170fba7f5a7ea2b70e1323f88146adf3ce50f.tar.gz",
+            .hash = "nostr-0.3.6-JY6OcKvaDwD1I7e9mP9Q84fcu1K0GMfyhhkKSLx2SC_F",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Upstream, includes the epoll

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -45,10 +45,10 @@ linkFarm "zig-packages" [
     };
   }
   {
-    name = "nostr-0.3.6-JY6OcLPKDwAP8UJz5qRAVc4LKg3AB2zE7Eok-gky9o4d";
+    name = "nostr-0.3.6-JY6OcKvaDwD1I7e9mP9Q84fcu1K0GMfyhhkKSLx2SC_F";
     path = fetchzip {
-      url = "https://codeload.github.com/privkeyio/libnostr-z/tar.gz/refs/tags/v0.3.6";
-      hash = "sha256-uCt2U8KRoF0W2oK8KzB8rEt32lbD+pMaVwVL/9XaBYw=";
+      url = "https://codeload.github.com/privkeyio/libnostr-z/tar.gz/9a4170fba7f5a7ea2b70e1323f88146adf3ce50f";
+      hash = "sha256-WnU+uIvYA4gmRQRmWoyvYfFy7RUZxeoxzjERrQNiS0c=";
       extension = "tar.gz";
     };
   }


### PR DESCRIPTION
Picks up `privkeyio/libnostr-z#138`, which makes loading a negentropy reconciliation session linear instead of quadratic.

Each `insert` moved every element after its sorted position, and wisp enumerates a newest-first index, so every record landed at index 0 and shifted the whole array. For a large match set that is O(n²) memmove on a handler thread while the peer waits — and NEG-OPEN is unauthenticated by default, with `negentropy_max_sync_events` defaulting to a million.

## Pinning choice

Pinned **by commit**, not by tag, so this does not require cutting a libnostr-z release. That is your call, not mine, and `httpz` and `websocket` in this same manifest are already pinned by commit, so it is not a new pattern here.

The hash still reads `nostr-0.3.6-…` because that is the version in the dependency's own `build.zig.zon`; the digest is what identifies the content. There is a comment in the manifest saying so, since a reader could otherwise assume it is the 0.3.6 release.

Say the word if you would rather I cut `v0.3.7` in libnostr-z and pin the tag instead — `main` there is 3 commits past v0.3.6 (this fix plus two CI-only changes), so a release would be clean.

## Verification

Unit tests do not exercise the dependency's storage, so the real check is end to end against a built relay:

- NIP-77 sync between two relays: **3 passed, 0 failed**
- Match set of exactly `negentropy_max_sync_events`: **3 passed, 0 failed** (the boundary case fixed in #174, re-verified against the new dependency)

65/65 unit tests.

Upstream, the change keeps the ordering contract intact rather than requiring callers to `seal()`: every read path sorts first if a record arrived out of order. That mattered because libnostr-z's own tests insert and then read without sealing, so making appending observable would have been a silent breaking change. It is mutation-verified there — disabling the lazy sort fails the new ordering tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Nostr dependency to a pinned revision containing a negentropy storage performance fix.
* **Documentation**
  * Added an unreleased changelog entry documenting the dependency update and performance improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->