### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-11
+
+Correctness and hardening across the query, reconciliation and configuration
+paths, found while verifying the watchdog work that went into 0.5.15.
+
+The theme is silence: a failed storage read was reported as a finished result
+set, a negentropy session sealed and reconciled a partial one, config values
+that could never take effect were accepted without a word, and a write that
+failed partway left a truncated frame on a connection that stayed open. Each of
+those now says so.
+
+Two changes can alter behavior on upgrade; see the upgrade notes below before
+rolling out.
+
 ### Changed
 
-- Bumped libnostr-z past v0.3.6 to pick up a negentropy storage fix. Loading records into a reconciliation session was O(n^2), because each insert moved every element after it and wisp enumerates a newest-first index, so every record landed at the front and shifted the whole array. Serving a NEG-OPEN over a large match set spent that time on a handler thread while the peer waited (#178)
+- Bumped libnostr-z to v0.3.7 to pick up a negentropy storage fix. Loading records into a reconciliation session was O(n^2), because each insert moved every element after it and wisp enumerates a newest-first index, so every record landed at the front and shifted the whole array. Serving a NEG-OPEN over a large match set spent that time on a handler thread while the peer waited (#178)
 
 ### Added
 
@@ -222,7 +236,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Import/export to JSONL format
 - Configuration via TOML file or environment variables
 
-[Unreleased]: https://github.com/privkeyio/wisp/compare/v0.5.15...HEAD
+[Unreleased]: https://github.com/privkeyio/wisp/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/privkeyio/wisp/compare/v0.5.15...v0.6.0
 [0.5.15]: https://github.com/privkeyio/wisp/compare/v0.5.14...v0.5.15
 [0.5.14]: https://github.com/privkeyio/wisp/compare/v0.5.13...v0.5.14
 [0.5.13]: https://github.com/privkeyio/wisp/compare/v0.5.12...v0.5.13

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.5.15",
+    .version = "0.6.0",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll
@@ -13,16 +13,9 @@
             .url = "https://github.com/karlseguin/websocket.zig/archive/b70e733bc0d0ba0a98ff5fe5ef64d3017c85f369.tar.gz",
             .hash = "websocket-0.1.0-ZPISdUoQBQC7zw1uSwbOEYdxZiTxNN4nf9RlWBsN0_Nd",
         },
-        // Pinned past v0.3.6 by commit for the negentropy storage fix: loading
-        // records used to be O(n^2) because each insert moved every element
-        // after it, and wisp enumerates a newest-first index, so every record
-        // landed at index 0 and shifted the whole array. Serving NEG-OPEN over a
-        // large match set spent that time on a handler thread. The manifest
-        // still says 0.3.6 because that is the version in the dependency's own
-        // build.zig.zon; the digest is what identifies the content.
         .nostr = .{
-            .url = "https://github.com/privkeyio/libnostr-z/archive/9a4170fba7f5a7ea2b70e1323f88146adf3ce50f.tar.gz",
-            .hash = "nostr-0.3.6-JY6OcKvaDwD1I7e9mP9Q84fcu1K0GMfyhhkKSLx2SC_F",
+            .url = "https://github.com/privkeyio/libnostr-z/archive/refs/tags/v0.3.7.tar.gz",
+            .hash = "nostr-0.3.7-JY6OcKvaDwCO3EVbmfv4WRreC-IPbZHtrBAAyMHNYmWH",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
         // websocket.zig's epoll worker pool. Upstream, includes the epoll

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -45,10 +45,10 @@ linkFarm "zig-packages" [
     };
   }
   {
-    name = "nostr-0.3.6-JY6OcKvaDwD1I7e9mP9Q84fcu1K0GMfyhhkKSLx2SC_F";
+    name = "nostr-0.3.7-JY6OcKvaDwCO3EVbmfv4WRreC-IPbZHtrBAAyMHNYmWH";
     path = fetchzip {
-      url = "https://codeload.github.com/privkeyio/libnostr-z/tar.gz/9a4170fba7f5a7ea2b70e1323f88146adf3ce50f";
-      hash = "sha256-WnU+uIvYA4gmRQRmWoyvYfFy7RUZxeoxzjERrQNiS0c=";
+      url = "https://codeload.github.com/privkeyio/libnostr-z/tar.gz/refs/tags/v0.3.7";
+      hash = "sha256-7+p+6Jt7vKU3XZvIDO2oqtWqKGCky+/h1vmTevK4XVM=";
       extension = "tar.gz";
     };
   }

--- a/src/main.zig
+++ b/src/main.zig
@@ -157,7 +157,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.5.15 starting", .{});
+    std.log.info("Wisp v0.6.0 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,51,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.5.15\"");
+    try w.writeAll(",\"version\":\"0.6.0\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Twelve merged changes since v0.5.15, plus the version bump and a repin of libnostr-z to its new tagged release.

## Why a minor bump

`CONTRIBUTING.md` treats "changing default behavior" as breaking, which takes a minor bump pre-1.0. Two changes qualify:

- An unrecognized boolean in a config file now **fails the load** instead of silently meaning `false`. Under a supervisor that is a restart loop until corrected, so validate configs before rolling out.
- A connection whose write fails is now **closed** instead of skipped.

Both are in the upgrade notes, along with the `trust_proxy` case where a previously misparsed `TRUE` now correctly turns something *on*.

## The theme

Silence. A failed storage read was reported as a finished result set on all three query paths; a negentropy session sealed and reconciled a partial one, which makes the relay report events as missing that it actually holds; config values that could never take effect were accepted without a word; and a write that failed partway left a truncated frame on a connection that stayed open, so everything after it was garbage. Each of those now says so.

Also in the release: NEG-OPEN no longer holds an LMDB read transaction open across a 128 KiB network write, a negentropy set of exactly the cap reconciles instead of being rejected, IP list entries that can never match are refused at load, and the vendored httpz tree is now checked against upstream in CI.

## Dependency

libnostr-z moves from the bare commit this branch previously pinned to the **v0.3.7** tag, released for this purpose. The manifest hash now reads `nostr-0.3.7-…` instead of claiming `0.3.6` while carrying newer code, which matters for anyone auditing a shipped release. `nix/deps.nix` mirrors it — that file is not covered by CI, and a bump that missed it would have left Nix builds on the old dependency.

## Verification

- 65/65 unit tests.
- Against the built relay: the NIP-11 document and the startup banner both report `0.6.0`.
- NIP-77 sync between two relays and the exactly-at-the-cap boundary both re-verified against the tagged dependency.

Note for packagers: v0.5.15 is a valid release and contains the watchdog fix, but nothing downstream picked it up, so consumers on v0.5.14 upgrade straight to this.