### PR TITLE
Re-pin vendored httpz to upstream now that the timeout-sweep fix landed

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -18,17 +18,25 @@
             .hash = "nostr-0.3.7-JY6OcKvaDwCO3EVbmfv4WRreC-IPbZHtrBAAyMHNYmWH",
         },
         // http.zig: HTTP routing (NIP-11/NIP-86) + WebSocket upgrade onto
-        // websocket.zig's epoll worker pool. Upstream, includes the epoll
-        // recv-on-freed-Conn fix (#216) and the shutdown-buffer join-order fix
-        // (#217), alongside the prior fixes (#215, #214, #213). Pins the same
-        // websocket commit (b70e733) as above so they dedup.
-        // Vendored (see vendor/httpz) from upstream commit 01dc09453ae5, with a
-        // local patch to the NonBlocking epoll worker that reclaims the
-        // per-worker connection slot (self.len) and frees the Conn wrapper when a
-        // WebSocket closes (wisp-ci1: accept-stall leak) and guards the handover
-        // union access against a .websocket conn (wisp-8sk: union panic). Kept as
-        // a path dependency so a clean `zig build` (incl. the StartOS Docker
-        // fetch) picks up the fix with no external fork.
+        // websocket.zig's epoll worker pool.
+        //
+        // Vendored (see vendor/httpz) from upstream commit dce2cb07f1cd, which
+        // now carries the timeout-sweep fix we previously patched locally: a
+        // sweep containing both expired and surviving connections dropped every
+        // survivor from the tracking list, so those connections never timed out
+        // and held a worker slot for the life of the process. That upstream
+        // commit also strengthens the acquireProcessing ordering to .acquire per
+        // a TSan report, which the local patch below depends on.
+        //
+        // What remains local, recorded in vendor/httpz.patch and enforced by
+        // scripts/verify-vendored-httpz.sh in CI: reclaiming the per-worker slot
+        // (self.len) and freeing the Conn wrapper when a WebSocket closes
+        // (accept-stall leak), guarding the handover union against a .websocket
+        // conn, routing every slot release through a guarded helper, and a
+        // connectionCount() accessor the watchdog reads as a liveness signal.
+        //
+        // Kept as a path dependency so a clean `zig build` (incl. the StartOS
+        // Docker fetch) builds this tree with no external fork.
         .httpz = .{
             .path = "vendor/httpz",
         },

--- a/scripts/regenerate-vendored-httpz-patch.sh
+++ b/scripts/regenerate-vendored-httpz-patch.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 UPSTREAM_REPO="https://github.com/karlseguin/http.zig"
-UPSTREAM_COMMIT="01dc09453ae50b82cc74ac2f90e9cd57e0b38500"
+UPSTREAM_COMMIT="dce2cb07f1cd9beca6146869e1eec48025cf9f6f"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 

--- a/scripts/verify-vendored-httpz.sh
+++ b/scripts/verify-vendored-httpz.sh
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 UPSTREAM_REPO="https://github.com/karlseguin/http.zig"
-UPSTREAM_COMMIT="01dc09453ae50b82cc74ac2f90e9cd57e0b38500"
+UPSTREAM_COMMIT="dce2cb07f1cd9beca6146869e1eec48025cf9f6f"
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 vendor_dir="$repo_root/vendor/httpz"

--- a/vendor/httpz.patch
+++ b/vendor/httpz.patch
@@ -52,14 +52,14 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
          // A pool of HTTPConn objects. The pool maintains a configured min # of these.
          // An HTTPConn is relatively expensive, since we pre-allocate all types
          // of things (a Request.State and Response.State).
-@@ -488,6 +497,7 @@
+@@ -487,6 +496,7 @@
+                 .active_list = .{},
                  .request_list = .{},
                  .handover_list = .{},
-                 .keepalive_list = .{},
 +                .websocket_close_list = .{},
+                 .keepalive_list = .{},
                  .buffer_pool = buffer_pool,
                  .conn_mem_pool = conn_mem_pool,
-                 .http_conn_pool = http_conn_pool,
 @@ -782,7 +792,15 @@
  
              while (c) |conn| {
@@ -181,38 +181,12 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              self.http_conn_pool.release(http_conn);
              self.conn_mem_pool.destroy(conn);
          }
-@@ -970,6 +1043,11 @@
-             while (conn) |c| {
-                 const timeout = c.protocol.http.timeout;
-                 if (timeout > now) {
-+                    // Detach the survivor from the expired prefix before it
-+                    // becomes the head. Those nodes are about to be destroyed,
-+                    // so a stale prev would leave this connection pointing into
-+                    // memory the pool has recycled.
-+                    c.prev = null;
-                     list.head = c;
-                     return .{ timed_out, count, timeout };
-                 }
-@@ -982,12 +1060,21 @@
-             return .{ timed_out, count, null };
-         }
- 
-+        // Releases connections that collectTimedOut already spliced out of their
-+        // owning list. It must not go through disown(): that removes the node
-+        // from request_list/keepalive_list a second time, and List.remove
-+        // rewrites head/tail from a node that is no longer a member. The effect
-+        // was that a sweep with both expired and surviving entries dropped every
-+        // survivor from the list, so those connections never timed out and held
-+        // a worker slot for the life of the process.
-         fn closeList(self: *Self, list: List(Conn(WSH))) void {
-             var conn = list.head;
+@@ -995,7 +1068,7 @@
              while (conn) |c| {
                  conn = c.next;
                  c.close();
--                self.disown(c);
+-                self.len -= 1;
 +                self.releaseSlot();
-+                self.http_conn_pool.release(c.protocol.http);
-+                self.conn_mem_pool.destroy(c);
+                 self.http_conn_pool.release(c.protocol.http);
+                 self.conn_mem_pool.destroy(c);
              }
-         }
- 

--- a/vendor/httpz/build.zig
+++ b/vendor/httpz/build.zig
@@ -31,6 +31,7 @@ pub fn build(b: *std.Build) !void {
         const test_filter = b.option([]const []const u8, "test-filter", "Filters for test: specify multiple times for multiple filters");
         const tests = b.addTest(.{
             .root_module = httpz_module,
+            .use_llvm = true,
             .filters = test_filter orelse &.{},
             .test_runner = .{ .path = b.path("test_runner.zig"), .mode = .simple },
         });

--- a/vendor/httpz/src/httpz.zig
+++ b/vendor/httpz/src/httpz.zig
@@ -371,13 +371,13 @@ pub fn Server(comptime H: type) type {
                 break :blk try posix.socket(address.any.family, sock_flags, proto);
             };
 
-            if (is_unix_socket) {
-                // TODO: Broken on darwin:
-                // https://github.com/ziglang/zig/issues/17260
-                // if (@hasDecl(os.TCP, "NODELAY")) {
-                //  try os.setsockopt(socket.sockfd.?, os.IPPROTO.TCP, os.TCP.NODELAY, &std.mem.toBytes(@as(c_int, 1)));
-                // }
-                try posix.setsockopt(listener, posix.IPPROTO.TCP, 1, &std.mem.toBytes(@as(c_int, 1)));
+            errdefer {
+                posix.close(listener);
+                self._listener = null;
+            }
+
+            if (is_unix_socket == false) {
+                try posix.setsockopt(listener, posix.IPPROTO.TCP, posix.TCP.NODELAY, &std.mem.toBytes(@as(c_int, 1)));
             }
 
             try posix.setsockopt(listener, posix.SOL.SOCKET, posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));

--- a/vendor/httpz/src/posix.zig
+++ b/vendor/httpz/src/posix.zig
@@ -11,6 +11,7 @@ pub const AF = posix.AF;
 pub const SO = posix.SO;
 pub const SOL = posix.SOL;
 pub const SOCK = posix.SOCK;
+pub const TCP = posix.TCP;
 pub const fd_t = posix.fd_t;
 pub const socket_t = posix.socket_t;
 pub const timeval = posix.timeval;

--- a/vendor/httpz/src/worker.zig
+++ b/vendor/httpz/src/worker.zig
@@ -496,8 +496,8 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 .active_list = .{},
                 .request_list = .{},
                 .handover_list = .{},
-                .keepalive_list = .{},
                 .websocket_close_list = .{},
+                .keepalive_list = .{},
                 .buffer_pool = buffer_pool,
                 .conn_mem_pool = conn_mem_pool,
                 .http_conn_pool = http_conn_pool,
@@ -1043,10 +1043,9 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             while (conn) |c| {
                 const timeout = c.protocol.http.timeout;
                 if (timeout > now) {
-                    // Detach the survivor from the expired prefix before it
-                    // becomes the head. Those nodes are about to be destroyed,
-                    // so a stale prev would leave this connection pointing into
-                    // memory the pool has recycled.
+                    // The expired connections ahead of this one were moved into
+                    // `timed_out` and are about to be destroyed, so this node
+                    // must not keep pointing back into them.
                     c.prev = null;
                     list.head = c;
                     return .{ timed_out, count, timeout };
@@ -1060,13 +1059,10 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             return .{ timed_out, count, null };
         }
 
-        // Releases connections that collectTimedOut already spliced out of their
-        // owning list. It must not go through disown(): that removes the node
-        // from request_list/keepalive_list a second time, and List.remove
-        // rewrites head/tail from a node that is no longer a member. The effect
-        // was that a sweep with both expired and surviving entries dropped every
-        // survivor from the list, so those connections never timed out and held
-        // a worker slot for the life of the process.
+        // `list` holds connections that collectTimedOut already detached from
+        // request_list/keepalive_list, so they must not be removed from those
+        // again. disown() would do exactly that, and List.remove rewrites head
+        // and tail from a node that is no longer a member.
         fn closeList(self: *Self, list: List(Conn(WSH))) void {
             var conn = list.head;
             while (conn) |c| {
@@ -1665,7 +1661,7 @@ pub fn Conn(comptime WSH: type) type {
 
         pub fn acquireProcessing(self: *Self) bool {
             // returns true if it was previously false
-            return @atomicRmw(bool, &self.processing, .Xchg, true, .monotonic) == false;
+            return @atomicRmw(bool, &self.processing, .Xchg, true, .acquire) == false;
         }
 
         pub fn releaseProcessing(self: *Self) void {


### PR DESCRIPTION
Re-pins the vendored copy of http.zig to upstream `dce2cb07f1cd`, replacing the previous pin at `01dc09453ae5`.

## Why now

The local patch we carried included a fix to the connection timeout sweep: when a sweep contained both expired and surviving connections, the survivors were dropped from the tracking list entirely, so they never timed out and held a worker slot for the life of the process. That fix has since been accepted upstream, so it no longer needs to live in our patch file.

## Everything else the re-pin picks up

Beyond the timeout-sweep fix, the pin advances by four more upstream changes. Listing all of them so the delta is not left for the next reader to derive:

- an ordering fix strengthening `acquireProcessing` from `.monotonic` to `.acquire`, in response to a ThreadSanitizer report. This one matters to us specifically: our remaining WebSocket slot-reclamation patch relies on `processing` to prevent a connection being dispatched twice, so the stronger ordering reinforces the invariant our patch depends on.
- `TCP_NODELAY` is now set on the TCP listening socket rather than attempted on the unix-socket path (where it would have failed `ENOPROTOOPT`). Behaviorally inert for us, since `src/server.zig` already sets `TCP_NODELAY` per connection.
- a listener errdefer that closes the socket and resets `_listener` when `listen()` fails partway. Safe with our shutdown: `stop()` is called exactly once, and the errdefers unwind `_listener = null` before releasing the mutex, so a concurrent `stop()` always observes the null and skips the close.
- `use_llvm = true` on httpz's own test binary, which does not affect our build.

## What is still local

`vendor/httpz.patch` shrinks from 218 to 192 lines. The timeout-sweep hunks are gone; what remains is:

- reclaiming the per-worker slot (`self.len`) and freeing the `Conn` wrapper when a WebSocket closes, via a close list drained on the event-loop thread (the accept-stall leak)
- guarding the handover union against a `.websocket` conn, which would otherwise abort the process on a misread union field
- routing every slot release through a guarded `releaseSlot()` helper, so a double release logs instead of panicking in ReleaseSafe or wrapping to ~2^64 in ReleaseFast (the latter would silently disable the `max_conn` cap)
- a `connectionCount()` accessor the watchdog reads as a liveness signal

`scripts/verify-vendored-httpz.sh` enforces that the vendored tree equals upstream plus exactly this patch, and runs in CI.

## Verification

Unit: `zig build test`, 11/11 steps, 65/65 tests.

End-to-end against a ReleaseSafe binary:

- **Staggered reap** (the regression this pin is about): three idle connections opened three seconds apart were reaped at 10.3s, 13.3s and 16.3s, each at its own deadline. Before the fix this same harness produced `10.3s, NEVER, NEVER`.
- **WebSocket idle reclaim**: 6/6, including slot reclamation and per-IP limiter bucket reclamation, with no slot-accounting underflow logged (the signal that would fire if the guarded release collided with upstream's sweep).
- **Protocol suite**: 45/45.
- **Concurrency**: 2/2, including 200 concurrent connections.
- **NIP-77 negentropy sync**: 3/3. **NIP-77 boundary at the cap**: 3/3.

No errors, panics or underflow warnings in any relay log across the runs.
