### PR TITLE
Release handover connections directly instead of through disown()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,28 @@ jobs:
           stop "$pid"; wait "$pid" 2>/dev/null
           exit $rc
 
+      - name: Run handover-list leak test (interleaved ws upgrade + close handover)
+        run: |
+          stop() {
+            kill "$1" 2>/dev/null || return 0
+            for i in $(seq 1 20); do kill -0 "$1" 2>/dev/null || return 0; sleep 0.25; done
+            kill -9 "$1" 2>/dev/null || true
+          }
+          # one worker so every connection shares a single handover_list, and a
+          # per-IP limit far above the test's concurrency: rejected connections
+          # never reach a handover, so a low limit would make the test vacuous
+          nohup env WISP_HOST=127.0.0.1 WISP_PORT=7788 WISP_WORKERS=1 \
+            WISP_MAX_CONNECTIONS_PER_IP=100000 \
+            WISP_STORAGE_PATH="$RUNNER_TEMP/wisp-handover" \
+            ./zig-out/bin/wisp relay > relay-handover.log 2>&1 &
+          pid=$!
+          for i in $(seq 1 40); do nc -z 127.0.0.1 7788 && break; sleep 0.25; done
+          nc -z 127.0.0.1 7788 || { echo "relay never listened on 7788"; cat relay-handover.log 2>/dev/null; stop "$pid"; wait "$pid" 2>/dev/null; exit 1; }
+          bash tests/integration_handover_leak.sh ws://127.0.0.1:7788 "$pid"
+          rc=$?
+          stop "$pid"; wait "$pid" 2>/dev/null
+          exit $rc
+
       - name: Run WS rate-limit test
         run: |
           stop() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A connection handed over in the same batch as another could be dropped from
+  every tracking list, leaking its slot and file descriptor and leaving the
+  worker spinning on it. The epoll worker snapshots its handover list by taking
+  the head and clearing the list, but the snapshot entries keep their links, so
+  releasing one through the general path rewrote the live list's head and tail
+  from stale pointers. Anything handed over before the next drain was then
+  unreachable by any timeout sweep, while its still-registered socket was
+  re-reported on every loop iteration. Reachable remotely without
+  authentication by interleaving WebSocket upgrades with requests that end in a
+  close. Measured on the unfixed build: 42 leaked descriptors and a core pinned
+  at 99.6% after the load stopped (#181)
+
 ## [0.6.0] - 2026-08-11
 
 Correctness and hardening across the query, reconciliation and configuration

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,8 +26,19 @@ relay's URL (start a relay first, e.g. `./zig-out/bin/wisp`):
     bash tests/integration_concurrency.sh ws://127.0.0.1:7777  # many concurrent conns
     bash tests/integration_ws_idle_reclaim.sh ws://127.0.0.1:7777 # idle-close slot/bucket reclaim
 
+    bash tests/integration_ws_rate_limit.sh ws://127.0.0.1:7777   # per-IP token buckets
+    bash tests/integration_handover_leak.sh ws://127.0.0.1:7777 PID # handover slot/fd leak
+
 The idle-reclaim test needs a dedicated relay (no other WebSocket clients)
 started with a short idle window and a per-IP limit of 2, e.g.
 `WISP_IDLE_SECONDS=1 WISP_MAX_CONNECTIONS_PER_IP=2`.
+
+The handover-leak test is Linux-only: it counts the relay's own socket
+descriptors and CPU time under `/proc`, so it takes the relay's **pid as a
+second argument** and exits immediately without one. It needs a dedicated relay
+started with `WISP_WORKERS=1` (so every connection shares one handover list) and
+a per-IP limit far above its concurrency, e.g.
+`WISP_MAX_CONNECTIONS_PER_IP=100000`. With a low limit the connections are
+rejected before they ever reach a handover and the test proves nothing.
 
 These mirror the jobs in `.github/workflows/ci.yml`.

--- a/tests/integration_handover_leak.sh
+++ b/tests/integration_handover_leak.sh
@@ -35,8 +35,9 @@ HOST="${HOSTPORT%%:*}"
 PORT="${HOSTPORT##*:}"
 ROUNDS="${ROUNDS:-40}"
 PAIRS="${PAIRS:-12}"
-# Must exceed the request + keepalive timeouts so every legitimate connection has
-# been swept before we count what is left.
+# Must exceed http_request_timeout_s + http_keepalive_timeout_s (see the defaults
+# in src/server.zig) so every legitimate connection has been swept before we
+# count what is left. Raising either default means raising this too.
 SETTLE="${SETTLE:-25}"
 pass=0
 fail=0
@@ -112,6 +113,18 @@ done
 
 sleep "$SETTLE"
 
+# If the relay died during the load, ticks() and sockets() both read 0 and every
+# assertion below would print ok. Fail closed instead.
+if kill -0 "$PID" 2>/dev/null; then
+  echo "ok   - relay process still alive after load"
+  pass=$((pass + 1))
+else
+  echo "FAIL - relay process exited during the load; measurements below are meaningless"
+  echo "-----"
+  echo "$pass passed, $((fail + 1)) failed"
+  exit 1
+fi
+
 # A connect refused by the OS or the relay produces no handover at all, so
 # without this floor the fd and tick assertions could pass having exercised
 # nothing. Require at least half of each kind to have connected.
@@ -133,7 +146,7 @@ fi
 ticks() { # relay CPU ticks (utime + stime)
   local st
   st="$(cat "/proc/$PID/stat" 2>/dev/null)" || { printf '0'; return; }
-  st="${st#*) }"
+  st="${st##*) }"
   awk -v x="$st" 'BEGIN{n=split(x,f," "); print f[12]+f[13]}'
 }
 hz="$(getconf CLK_TCK 2>/dev/null)"

--- a/tests/integration_handover_leak.sh
+++ b/tests/integration_handover_leak.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Black-box guard for the handover_list corruption fix: a WebSocket upgrade and a
+# close-handover request landing in the same processSignal batch must not orphan
+# connections.
+#
+# processSignal snapshots handover_list (takes head, clears inner) but leaves each
+# node's next/prev intact. The .websocket branch is the only one that neither
+# removes its node nor releases it, so a [websocket, close] chain used to have
+# disown() call handover_list.remove() on a non-member, writing the live list's
+# tail back to that stale node while head stayed null. Every handover inserted
+# before the next drain was then unreachable: slot never released, fd never
+# closed, and in no timeout list, so no sweep could ever reap it.
+#
+# The leak is invisible to unit tests and does not show up in
+# wisp_connections_active (the orphans include plain HTTP conns), so this drives
+# real connections and counts the relay's own socket fds afterwards. Measured on
+# the unfixed build this reported 42 sockets still held; fixed, it reports ~1.
+#
+# The relay under test MUST be dedicated to this test and MUST be configured with
+# a per-IP limit well above the concurrency below (e.g.
+# WISP_MAX_CONNECTIONS_PER_IP=100000), otherwise connections are rejected by the
+# limiter before they ever reach a handover and the test proves nothing. A single
+# worker (WISP_WORKERS=1) concentrates every connection on one handover_list.
+#
+# Usage: tests/integration_handover_leak.sh [relay-url] [relay-pid]
+# Requires: bash (uses /dev/tcp) and curl. Linux only (reads /proc/PID/fd).
+#
+# Exits non-zero if any assertion fails, so it can gate CI.
+set -u
+R="${1:-ws://127.0.0.1:7777}"
+PID="${2:-}"
+HOSTPORT="${R#ws://}"
+HOSTPORT="${HOSTPORT%/}"
+HOST="${HOSTPORT%%:*}"
+PORT="${HOSTPORT##*:}"
+ROUNDS="${ROUNDS:-40}"
+PAIRS="${PAIRS:-12}"
+# Must exceed the request + keepalive timeouts so every legitimate connection has
+# been swept before we count what is left.
+SETTLE="${SETTLE:-25}"
+pass=0
+fail=0
+
+if [ -z "$PID" ]; then
+  echo "FAIL - relay pid required as \$2 (needed to count the relay's own fds)"
+  exit 1
+fi
+if [ ! -d "/proc/$PID/fd" ]; then
+  echo "FAIL - /proc/$PID/fd not readable (Linux only, and pid must be the relay)"
+  exit 1
+fi
+
+chk() { # desc expected actual
+  if [ "$2" = "$3" ]; then
+    echo "ok   - $1"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - $1 (expected '$2', got '$3')"
+    fail=$((fail + 1))
+  fi
+}
+
+sockets() { # count socket fds held by the relay
+  local n=0 l
+  for e in "/proc/$PID/fd"/*; do
+    l="$(readlink "$e" 2>/dev/null)" || continue
+    case "$l" in socket:*) n=$((n + 1)) ;; esac
+  done
+  printf '%s' "$n"
+}
+
+# A WebSocket upgrade that hands over as .websocket.
+upgrade() {
+  ( exec 3<>"/dev/tcp/$HOST/$PORT" || exit 0
+    printf 'GET / HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n' "$HOSTPORT" >&3
+    IFS= read -t 5 -r _ <&3 || true
+    # Hold briefly so this connection's .websocket handover is still in the list
+    # when a .close lands behind it. Closing immediately mostly misses the window.
+    sleep 0.05
+    exec 3>&- 3<&- ) 2>/dev/null &
+}
+
+# A plain HTTP request that hands over as .close.
+closereq() {
+  ( exec 3<>"/dev/tcp/$HOST/$PORT" || exit 0
+    printf 'GET / HTTP/1.1\r\nHost: %s\r\nAccept: application/nostr+json\r\nConnection: close\r\n\r\n' "$HOSTPORT" >&3
+    while IFS= read -t 5 -r _ <&3; do :; done || true
+    exec 3>&- 3<&- ) 2>/dev/null &
+}
+
+# The relay must be serving before we trust any count.
+srv="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://$HOSTPORT/metrics" 2>/dev/null)"
+chk "relay is serving before load" "200" "$srv"
+[ "$fail" -eq 0 ] || { echo "-----"; echo "$pass passed, $fail failed"; exit 1; }
+
+base="$(sockets)"
+case "$base" in ''|*[!0-9]*) base=0 ;; esac
+echo "info - baseline socket fds: $base"
+
+for _ in $(seq 1 "$ROUNDS"); do
+  for _ in $(seq 1 "$PAIRS"); do
+    upgrade
+    closereq
+  done
+  wait
+done
+
+sleep "$SETTLE"
+
+# Measured first: a spinning relay pins a core at ~100% indefinitely, which is
+# both the worst symptom and the fastest to detect. Unfixed, this burned 99.6%
+# of a core continuously; fixed, the relay is idle here.
+ticks() { # relay CPU ticks (utime + stime)
+  local st
+  st="$(cat "/proc/$PID/stat" 2>/dev/null)" || { printf '0'; return; }
+  st="${st#*) }"
+  awk -v x="$st" 'BEGIN{n=split(x,f," "); print f[12]+f[13]}'
+}
+hz="$(getconf CLK_TCK 2>/dev/null)"
+case "$hz" in ''|*[!0-9]*) hz=100 ;; esac
+t0="$(ticks)"
+sleep 5
+t1="$(ticks)"
+burn=$((t1 - t0))
+# 5 idle seconds should cost almost nothing. Fail past 30% of one core, far
+# above idle noise and far below the ~100% a spin produces.
+maxburn=$((hz * 5 * 30 / 100))
+if [ "$burn" -le "$maxburn" ]; then
+  echo "ok   - relay is not spinning while idle ($burn ticks over 5s, limit $maxburn)"
+  pass=$((pass + 1))
+else
+  echo "FAIL - relay is spinning on orphaned connections ($burn ticks over 5s, limit $maxburn)"
+  fail=$((fail + 1))
+fi
+
+after="$(sockets)"
+case "$after" in ''|*[!0-9]*) after=999 ;; esac
+echo "info - socket fds after load + ${SETTLE}s settle: $after"
+
+# The fixed build sits flat at the baseline across runs; the slack is for the
+# listener, the liveness probe's own connection and any in-flight teardown.
+# Verified by mutation: reverting releaseHandover() back to disown() pushes this
+# well past the threshold, while the fixed build stays at baseline.
+limit=$((base + 5))
+if [ "$after" -le "$limit" ]; then
+  echo "ok   - no connections orphaned by interleaved handovers ($after <= $limit)"
+  pass=$((pass + 1))
+else
+  echo "FAIL - connections orphaned by interleaved handovers ($after > $limit)"
+  fail=$((fail + 1))
+fi
+
+# A leak that stalls the accept loop would show up here too.
+srv="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://$HOSTPORT/metrics" 2>/dev/null)"
+chk "relay still serving after load" "200" "$srv"
+
+echo "-----"
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/tests/integration_handover_leak.sh
+++ b/tests/integration_handover_leak.sh
@@ -50,6 +50,9 @@ if [ ! -d "/proc/$PID/fd" ]; then
   exit 1
 fi
 
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/handover.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
 chk() { # desc expected actual
   if [ "$2" = "$3" ]; then
     echo "ok   - $1"
@@ -72,6 +75,7 @@ sockets() { # count socket fds held by the relay
 # A WebSocket upgrade that hands over as .websocket.
 upgrade() {
   ( exec 3<>"/dev/tcp/$HOST/$PORT" || exit 0
+    printf 'x' >>"$tmpdir/up"
     printf 'GET / HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n' "$HOSTPORT" >&3
     IFS= read -t 5 -r _ <&3 || true
     # Hold briefly so this connection's .websocket handover is still in the list
@@ -83,6 +87,7 @@ upgrade() {
 # A plain HTTP request that hands over as .close.
 closereq() {
   ( exec 3<>"/dev/tcp/$HOST/$PORT" || exit 0
+    printf 'x' >>"$tmpdir/close"
     printf 'GET / HTTP/1.1\r\nHost: %s\r\nAccept: application/nostr+json\r\nConnection: close\r\n\r\n' "$HOSTPORT" >&3
     while IFS= read -t 5 -r _ <&3; do :; done || true
     exec 3>&- 3<&- ) 2>/dev/null &
@@ -106,6 +111,21 @@ for _ in $(seq 1 "$ROUNDS"); do
 done
 
 sleep "$SETTLE"
+
+# A connect refused by the OS or the relay produces no handover at all, so
+# without this floor the fd and tick assertions could pass having exercised
+# nothing. Require at least half of each kind to have connected.
+ups=$(wc -c <"$tmpdir/up" 2>/dev/null || echo 0)
+closes=$(wc -c <"$tmpdir/close" 2>/dev/null || echo 0)
+want=$((ROUNDS * PAIRS / 2))
+echo "info - connections made: $ups upgrades, $closes close-handovers (floor $want each)"
+if [ "$ups" -ge "$want" ] && [ "$closes" -ge "$want" ]; then
+  echo "ok   - load actually reached the relay"
+  pass=$((pass + 1))
+else
+  echo "FAIL - too few connections completed; the assertions below would be vacuous"
+  fail=$((fail + 1))
+fi
 
 # Measured first: a spinning relay pins a core at ~100% indefinitely, which is
 # both the worst symptom and the fastest to detect. Unfixed, this burned 99.6%

--- a/vendor/httpz.patch
+++ b/vendor/httpz.patch
@@ -77,6 +77,32 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  switch (http_conn.handover) {
                      .close, .unknown => {
                          closed_bool.* = true;
+@@ -793,7 +811,7 @@
+                         // can deliver a .recv for the freed Conn.
+                         loop.remove(conn);
+                         conn.close();
+-                        self.disown(conn);
++                        self.releaseHandover(conn, http_conn);
+                     },
+                     .disown => {
+                         // When res.disown() was called, we immediately removed
+@@ -802,14 +820,14 @@
+                         // before we get back here.
+                         // https://github.com/karlseguin/http.zig/issues/129#issuecomment-3031411404
+                         closed_bool.* = true;
+-                        self.disown(conn);
++                        self.releaseHandover(conn, http_conn);
+                     },
+                     .websocket => |ptr| {
+                         if (comptime WSH == httpz.DummyWebsocketHandler) {
+                             std.debug.print("Your httpz handler must have a `WebsocketHandler` declaration. This must be the same type passed to `httpz.upgradeWebsocket`. Closing the connection.\n", .{});
+                             closed_bool.* = true;
+                             conn.close();
+-                            self.disown(conn);
++                            self.releaseHandover(conn, http_conn);
+                             continue;
+                         }
+ 
 @@ -821,14 +839,58 @@
                          loop.switchToOneShot(conn) catch {
                              metrics.internalError();
@@ -150,7 +176,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              } else {
                  // Release `processing` before re-arming. With EPOLLONESHOT, re-arming
                  // while still holding `processing` loses a read that arrives in the
-@@ -903,10 +965,21 @@
+@@ -903,10 +965,43 @@
                      log.debug("({f}) failed to add read event monitor: {}", .{ ws_conn.address, err });
                      ws_conn.close(.{ .code = 4998, .reason = "wsz" }) catch {};
                      self.websocket.cleanupConn(hc);
@@ -169,10 +195,32 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
 +            self.loop.signal() catch |err| log.err("failed to signal worker: {}", .{err});
 +        }
 +
++        // Releases a connection that processSignal already detached by taking the
++        // handover_list snapshot (head taken, inner cleared). It must not go
++        // through disown(): that dispatches on _state, which is still .handover,
++        // and so calls handover_list.remove() on a node that is no longer a
++        // member. List.remove rewrites head/tail from node.prev/node.next, and
++        // the .websocket branch leaves its node linked in the detached chain, so
++        // a [websocket, close] snapshot writes the live list's tail back to a
++        // non-member while head stays null. Every handover inserted before the
++        // next drain is then unreachable: its slot is never released, its fd is
++        // never closed, and it is in no timeout list, so nothing can ever reap
++        // it. Same defect class as the upstream timeout-sweep fix in
++        // collectTimedOut/closeList.
++        //
++        // Note this cannot be fixed by clearing next/prev when snapshotting:
++        // remove() would then null out head/tail directly, discarding entries
++        // that worker threads inserted after the snapshot was taken.
++        fn releaseHandover(self: *Self, conn: *Conn(WSH), http_conn: *HTTPConn) void {
++            self.releaseSlot();
++            self.http_conn_pool.release(http_conn);
++            self.conn_mem_pool.destroy(conn);
++        }
++
          fn disown(self: *Self, conn: *Conn(WSH)) void {
              const io = self.io;
              const http_conn = conn.protocol.http;
-@@ -916,7 +989,7 @@
+@@ -916,7 +1011,7 @@
                  .keepalive => self.keepalive_list.remove(io, conn),
                  .active => unreachable,
              }
@@ -181,7 +229,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              self.http_conn_pool.release(http_conn);
              self.conn_mem_pool.destroy(conn);
          }
-@@ -995,7 +1068,7 @@
+@@ -995,7 +1090,7 @@
              while (conn) |c| {
                  conn = c.next;
                  c.close();

--- a/vendor/httpz.patch
+++ b/vendor/httpz.patch
@@ -60,7 +60,21 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  .keepalive_list = .{},
                  .buffer_pool = buffer_pool,
                  .conn_mem_pool = conn_mem_pool,
-@@ -782,7 +792,15 @@
+@@ -675,6 +685,13 @@
+                 .active => self.active_list.remove(io, conn),
+                 .keepalive => self.keepalive_list.remove(io, conn),
+                 .request => self.request_list.remove(conn),
++                // Unreachable in practice: both callers (run()'s parse-error
++                // path and accept()'s errdefer) only ever hold .request or
++                // .keepalive conns, and .handover conns are released through
++                // releaseHandover instead. Left as a plain remove rather than
++                // `unreachable` so that a wrong analysis degrades to a stale
++                // list entry instead of aborting a live relay. Do NOT route a
++                // handover-snapshot node here; see releaseHandover for why.
+                 .handover => self.handover_list.remove(io, conn),
+             }
+ 
+@@ -782,7 +799,15 @@
  
              while (c) |conn| {
                  c = conn.next;
@@ -77,7 +91,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  switch (http_conn.handover) {
                      .close, .unknown => {
                          closed_bool.* = true;
-@@ -793,7 +811,7 @@
+@@ -793,7 +818,7 @@
                          // can deliver a .recv for the freed Conn.
                          loop.remove(conn);
                          conn.close();
@@ -86,7 +100,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                      },
                      .disown => {
                          // When res.disown() was called, we immediately removed
-@@ -802,14 +820,14 @@
+@@ -802,14 +827,14 @@
                          // before we get back here.
                          // https://github.com/karlseguin/http.zig/issues/129#issuecomment-3031411404
                          closed_bool.* = true;
@@ -103,7 +117,19 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                              continue;
                          }
  
-@@ -821,14 +839,58 @@
+@@ -817,18 +842,70 @@
+ 
+                         const hc: *ws.HandlerConn(WSH) = @ptrCast(@alignCast(ptr));
+                         conn.protocol = .{ .websocket = hc };
++                        // This node is in no list (the snapshot detached the
++                        // chain and `c` was advanced above), but its links still
++                        // point at Conns that releaseHandover frees in this same
++                        // pass. Nothing dereferences them today only because
++                        // List.insert overwrites both fields; null them so that
++                        // stays true without depending on it.
++                        conn.next = null;
++                        conn.prev = null;
+ 
                          loop.switchToOneShot(conn) catch {
                              metrics.internalError();
                              closed_bool.* = true;
@@ -163,7 +189,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
          }
  
          // Entry-point of our thread pool. `thread_buf` is a thread-specific buffer
-@@ -885,10 +947,10 @@
+@@ -885,10 +962,10 @@
              if (success == false) {
                  ws_conn.close(.{ .code = 4997, .reason = "wsz" }) catch {};
                  self.websocket.cleanupConn(hc);
@@ -176,7 +202,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              } else {
                  // Release `processing` before re-arming. With EPOLLONESHOT, re-arming
                  // while still holding `processing` loses a read that arrives in the
-@@ -903,10 +965,43 @@
+@@ -903,10 +980,60 @@
                      log.debug("({f}) failed to add read event monitor: {}", .{ ws_conn.address, err });
                      ws_conn.close(.{ .code = 4998, .reason = "wsz" }) catch {};
                      self.websocket.cleanupConn(hc);
@@ -198,19 +224,36 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
 +        // Releases a connection that processSignal already detached by taking the
 +        // handover_list snapshot (head taken, inner cleared). It must not go
 +        // through disown(): that dispatches on _state, which is still .handover,
-+        // and so calls handover_list.remove() on a node that is no longer a
-+        // member. List.remove rewrites head/tail from node.prev/node.next, and
-+        // the .websocket branch leaves its node linked in the detached chain, so
-+        // a [websocket, close] snapshot writes the live list's tail back to a
-+        // non-member while head stays null. Every handover inserted before the
-+        // next drain is then unreachable: its slot is never released, its fd is
-+        // never closed, and it is in no timeout list, so nothing can ever reap
-+        // it. Same defect class as the upstream timeout-sweep fix in
++        // so it calls handover_list.remove() on a node that is no longer a
++        // member.
++        //
++        // The general rule is that a snapshot node's prev/next are stale with
++        // respect to the live list, so List.remove -- which rewrites head/tail
++        // from exactly those two fields -- writes garbage into a list the node
++        // no longer belongs to. Worker threads keep inserting into that live
++        // list the whole time, so there is always something to corrupt. Two
++        // shapes, both reachable:
++        //
++        //   [A(.close)] alone: prev and next are both null, so remove(A) sets
++        //   head = null and tail = null, wiping an entry that was inserted
++        //   after the snapshot was taken.
++        //
++        //   [B(.websocket), A(.close)]: the .websocket branch neither removes
++        //   its node nor releases it, so A.prev is still B. remove(A) leaves
++        //   head null and writes tail = B, a non-member, and every later insert
++        //   appends behind B until the next drain resets the list.
++        //
++        // Either way the affected connections become unreachable: the slot is
++        // never released, the fd is never closed, and they are in no timeout
++        // list, so nothing can ever reap them. They also keep the
++        // level-triggered epoll registration from accept(), so the loop
++        // re-reports and skips them on every iteration, pinning a core. Same
++        // defect class as the upstream timeout-sweep fix in
 +        // collectTimedOut/closeList.
 +        //
 +        // Note this cannot be fixed by clearing next/prev when snapshotting:
-+        // remove() would then null out head/tail directly, discarding entries
-+        // that worker threads inserted after the snapshot was taken.
++        // remove() would then null head/tail directly, which is precisely the
++        // first shape above.
 +        fn releaseHandover(self: *Self, conn: *Conn(WSH), http_conn: *HTTPConn) void {
 +            self.releaseSlot();
 +            self.http_conn_pool.release(http_conn);
@@ -220,7 +263,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
          fn disown(self: *Self, conn: *Conn(WSH)) void {
              const io = self.io;
              const http_conn = conn.protocol.http;
-@@ -916,7 +1011,7 @@
+@@ -916,7 +1043,7 @@
                  .keepalive => self.keepalive_list.remove(io, conn),
                  .active => unreachable,
              }
@@ -229,7 +272,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              self.http_conn_pool.release(http_conn);
              self.conn_mem_pool.destroy(conn);
          }
-@@ -995,7 +1090,7 @@
+@@ -995,7 +1122,7 @@
              while (conn) |c| {
                  conn = c.next;
                  c.close();

--- a/vendor/httpz/src/worker.zig
+++ b/vendor/httpz/src/worker.zig
@@ -811,7 +811,7 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                         // can deliver a .recv for the freed Conn.
                         loop.remove(conn);
                         conn.close();
-                        self.disown(conn);
+                        self.releaseHandover(conn, http_conn);
                     },
                     .disown => {
                         // When res.disown() was called, we immediately removed
@@ -820,14 +820,14 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                         // before we get back here.
                         // https://github.com/karlseguin/http.zig/issues/129#issuecomment-3031411404
                         closed_bool.* = true;
-                        self.disown(conn);
+                        self.releaseHandover(conn, http_conn);
                     },
                     .websocket => |ptr| {
                         if (comptime WSH == httpz.DummyWebsocketHandler) {
                             std.debug.print("Your httpz handler must have a `WebsocketHandler` declaration. This must be the same type passed to `httpz.upgradeWebsocket`. Closing the connection.\n", .{});
                             closed_bool.* = true;
                             conn.close();
-                            self.disown(conn);
+                            self.releaseHandover(conn, http_conn);
                             continue;
                         }
 
@@ -978,6 +978,28 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
         fn closeWebsocket(self: *Self, conn: *Conn(WSH)) void {
             self.websocket_close_list.insert(self.io, conn);
             self.loop.signal() catch |err| log.err("failed to signal worker: {}", .{err});
+        }
+
+        // Releases a connection that processSignal already detached by taking the
+        // handover_list snapshot (head taken, inner cleared). It must not go
+        // through disown(): that dispatches on _state, which is still .handover,
+        // and so calls handover_list.remove() on a node that is no longer a
+        // member. List.remove rewrites head/tail from node.prev/node.next, and
+        // the .websocket branch leaves its node linked in the detached chain, so
+        // a [websocket, close] snapshot writes the live list's tail back to a
+        // non-member while head stays null. Every handover inserted before the
+        // next drain is then unreachable: its slot is never released, its fd is
+        // never closed, and it is in no timeout list, so nothing can ever reap
+        // it. Same defect class as the upstream timeout-sweep fix in
+        // collectTimedOut/closeList.
+        //
+        // Note this cannot be fixed by clearing next/prev when snapshotting:
+        // remove() would then null out head/tail directly, discarding entries
+        // that worker threads inserted after the snapshot was taken.
+        fn releaseHandover(self: *Self, conn: *Conn(WSH), http_conn: *HTTPConn) void {
+            self.releaseSlot();
+            self.http_conn_pool.release(http_conn);
+            self.conn_mem_pool.destroy(conn);
         }
 
         fn disown(self: *Self, conn: *Conn(WSH)) void {

--- a/vendor/httpz/src/worker.zig
+++ b/vendor/httpz/src/worker.zig
@@ -685,6 +685,13 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 .active => self.active_list.remove(io, conn),
                 .keepalive => self.keepalive_list.remove(io, conn),
                 .request => self.request_list.remove(conn),
+                // Unreachable in practice: both callers (run()'s parse-error
+                // path and accept()'s errdefer) only ever hold .request or
+                // .keepalive conns, and .handover conns are released through
+                // releaseHandover instead. Left as a plain remove rather than
+                // `unreachable` so that a wrong analysis degrades to a stale
+                // list entry instead of aborting a live relay. Do NOT route a
+                // handover-snapshot node here; see releaseHandover for why.
                 .handover => self.handover_list.remove(io, conn),
             }
 
@@ -835,6 +842,14 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
 
                         const hc: *ws.HandlerConn(WSH) = @ptrCast(@alignCast(ptr));
                         conn.protocol = .{ .websocket = hc };
+                        // This node is in no list (the snapshot detached the
+                        // chain and `c` was advanced above), but its links still
+                        // point at Conns that releaseHandover frees in this same
+                        // pass. Nothing dereferences them today only because
+                        // List.insert overwrites both fields; null them so that
+                        // stays true without depending on it.
+                        conn.next = null;
+                        conn.prev = null;
 
                         loop.switchToOneShot(conn) catch {
                             metrics.internalError();
@@ -983,19 +998,36 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
         // Releases a connection that processSignal already detached by taking the
         // handover_list snapshot (head taken, inner cleared). It must not go
         // through disown(): that dispatches on _state, which is still .handover,
-        // and so calls handover_list.remove() on a node that is no longer a
-        // member. List.remove rewrites head/tail from node.prev/node.next, and
-        // the .websocket branch leaves its node linked in the detached chain, so
-        // a [websocket, close] snapshot writes the live list's tail back to a
-        // non-member while head stays null. Every handover inserted before the
-        // next drain is then unreachable: its slot is never released, its fd is
-        // never closed, and it is in no timeout list, so nothing can ever reap
-        // it. Same defect class as the upstream timeout-sweep fix in
+        // so it calls handover_list.remove() on a node that is no longer a
+        // member.
+        //
+        // The general rule is that a snapshot node's prev/next are stale with
+        // respect to the live list, so List.remove -- which rewrites head/tail
+        // from exactly those two fields -- writes garbage into a list the node
+        // no longer belongs to. Worker threads keep inserting into that live
+        // list the whole time, so there is always something to corrupt. Two
+        // shapes, both reachable:
+        //
+        //   [A(.close)] alone: prev and next are both null, so remove(A) sets
+        //   head = null and tail = null, wiping an entry that was inserted
+        //   after the snapshot was taken.
+        //
+        //   [B(.websocket), A(.close)]: the .websocket branch neither removes
+        //   its node nor releases it, so A.prev is still B. remove(A) leaves
+        //   head null and writes tail = B, a non-member, and every later insert
+        //   appends behind B until the next drain resets the list.
+        //
+        // Either way the affected connections become unreachable: the slot is
+        // never released, the fd is never closed, and they are in no timeout
+        // list, so nothing can ever reap them. They also keep the
+        // level-triggered epoll registration from accept(), so the loop
+        // re-reports and skips them on every iteration, pinning a core. Same
+        // defect class as the upstream timeout-sweep fix in
         // collectTimedOut/closeList.
         //
         // Note this cannot be fixed by clearing next/prev when snapshotting:
-        // remove() would then null out head/tail directly, discarding entries
-        // that worker threads inserted after the snapshot was taken.
+        // remove() would then null head/tail directly, which is precisely the
+        // first shape above.
         fn releaseHandover(self: *Self, conn: *Conn(WSH), http_conn: *HTTPConn) void {
             self.releaseSlot();
             self.http_conn_pool.release(http_conn);


### PR DESCRIPTION
Fixes a pre-existing defect in the vendored epoll worker where a connection handed over in the same batch as a WebSocket upgrade could be dropped from every tracking list, leaking its slot and fd and pinning a CPU core at 100% indefinitely.

## The bug

`processSignal` snapshots `handover_list` by taking `inner.head` and clearing `inner`, but the snapshot nodes keep their `next`/`prev`. `disown()` then dispatches on `_state`, which is still `.handover`, so it calls `handover_list.remove()` on a node that is no longer a member.

The general rule is that a snapshot node's links are stale with respect to the live list, and `List.remove` rewrites `head`/`tail` from exactly those two fields. Worker threads keep inserting into that live list throughout, so there is always something to corrupt. Two reachable shapes:

- `[A(.close)]` alone: `prev` and `next` are both null, so `remove(A)` sets `head = null` and `tail = null`, wiping an entry inserted after the snapshot was taken. No WebSocket involved.
- `[B(.websocket), A(.close)]`: the `.websocket` branch neither removes its node nor releases it, so `A.prev` is still `B`. `remove(A)` leaves `head` null and writes `tail = B`, a non-member; since `List.insert` only assigns `head` when `tail == null`, every later handover appends behind `B` until the next drain resets the list.

Either way the affected connections are in no list at all: the slot is never released, the fd is never closed, the `HTTPConn` is never returned, and they are in neither timeout list, so no sweep can ever reach them.

Worse, its epoll registration is the level-triggered `IN|RDHUP` from `accept`, so once the peer sends anything or half-closes, `epoll_wait` returns it every iteration and `run()` skips it via the `.handover` state check. That is an unbounded busy spin on the worker's event-loop thread.

This is the same defect class as the timeout-sweep fix that recently landed upstream, in the sibling code path.

## Reachability

Remote and unauthenticated: alternate WebSocket upgrades with requests that end in a `.close` handover (`Connection: close`, an HTTP/1.0 `GET /` for NIP-11, or an upgrade rejected by the per-IP limiter, which answers 429 and then hands over as `.close`).

## The fix

`releaseHandover()` releases a connection the snapshot already detached, without touching the list. `disown()` is still correct for its other callers, whose connections genuinely are members of the list they name.

Clearing `next`/`prev` at snapshot time would not work and is called out in a comment: `remove()` would then null `head`/`tail` outright, discarding entries that worker threads inserted after the snapshot was taken.

## Verification

Reproduced first, then fixed. Measured under identical load (interleaved upgrades and close-handovers against a single worker), with a temporary probe compiled in to detect the corrupt `head == null, tail != null` state directly rather than inferring it:

| | poisoning events | socket fds after settle |
|---|---|---|
| before | 18 | 42 |
| after | 0 | 1 |

The unfixed relay also sat at 99.6% CPU for over six minutes after the load stopped, confirming the busy spin.

`tests/integration_handover_leak.sh` guards it in CI, asserting both symptoms: no CPU burn while idle, and no orphaned fds. Validated by mutation, since a test that cannot fail proves nothing:

- fixed: 6/6 pass, 0 CPU ticks over 5s idle, fds flat at baseline
- reverting only `releaseHandover()` back to `disown()`: fails with `500 ticks over 5s` (exactly one full core) and orphaned fds over the threshold

An earlier, weaker version of this test passed on the unfixed build; it needed each upgrade held briefly so its handover sits adjacent to a close, which is the poisoning precondition.

Also green: `zig build test` 65/65, protocol suite 45/45, concurrency 2/2 at 200 connections, and `scripts/verify-vendored-httpz.sh`.


## Review follow-ups

- The explanation above originally claimed the corruption required a `.websocket` node in the snapshot. It does not: a lone `.close` node wipes both `head` and `tail`. Corrected here and in the code comment, since the narrower claim would mislead the next reader into thinking only upgrade traffic can trigger it.
- The test could pass on a corpse: if the relay died during the settle, both the fd count and the CPU reading degrade to 0 and every assertion printed `ok`. It now fails closed on a dead pid.
- The load generators swallowed connect failures, so refused connections were indistinguishable from completed ones. The test now counts successful connects and asserts a floor (CI reports 480 upgrades and 480 close-handovers against a floor of 240).
- The `.handover` arm of `disown()` is now unreachable. Left as a plain remove rather than `unreachable`, so that a wrong analysis degrades to a stale list entry instead of aborting a live relay, with a comment saying so.
- The surviving `.websocket` node's links are nulled, so the "nothing dereferences them" invariant is local rather than resting on `List.insert` overwriting both fields.
