### PR TITLE
Publish a handover connection only after releasing its mutex

### DIFF
--- a/vendor/httpz.patch
+++ b/vendor/httpz.patch
@@ -60,21 +60,58 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  .keepalive_list = .{},
                  .buffer_pool = buffer_pool,
                  .conn_mem_pool = conn_mem_pool,
-@@ -675,6 +685,13 @@
+@@ -668,13 +678,37 @@
+         fn swapList(self: *Self, conn: *Conn(WSH), new_state: HTTPConn.State) void {
+             const io = self.io;
+             const http_conn = conn.protocol.http;
+-            http_conn._mut.lockUncancelable(io);
+-            defer http_conn._mut.unlock(io);
+-
++            {
++                http_conn._mut.lockUncancelable(io);
++                defer http_conn._mut.unlock(io);
++                self.swapListLocked(conn, http_conn, new_state);
++            }
++
++            // Publishing to handover_list hands this conn to the event-loop
++            // thread, which may release it (releaseHandover) before this call
++            // even returns. So it MUST be the last thing that touches conn or
++            // http_conn: doing it inside the critical section above meant the
++            // deferred _mut.unlock() then wrote into an HTTPConn already
++            // returned to the pool or destroyed, which panics in Mutex.unlock
++            // with "switch on corrupt value" (reproduced) and is a silent
++            // write to recycled memory in ReleaseFast. The caller's
++            // loop.signal() afterwards deliberately touches neither.
++            if (new_state == .handover) self.handover_list.insert(io, conn);
++        }
++
++        // Everything that needs http_conn._mut held. Split out so the handover
++        // publish can happen strictly after the mutex is released.
++        fn swapListLocked(self: *Self, conn: *Conn(WSH), http_conn: *HTTPConn, new_state: HTTPConn.State) void {
++            const io = self.io;
+             switch (http_conn._state) {
                  .active => self.active_list.remove(io, conn),
                  .keepalive => self.keepalive_list.remove(io, conn),
                  .request => self.request_list.remove(conn),
-+                // Unreachable in practice: both callers (run()'s parse-error
-+                // path and accept()'s errdefer) only ever hold .request or
-+                // .keepalive conns, and .handover conns are released through
-+                // releaseHandover instead. Left as a plain remove rather than
-+                // `unreachable` so that a wrong analysis degrades to a stale
-+                // list entry instead of aborting a live relay. Do NOT route a
-+                // handover-snapshot node here; see releaseHandover for why.
++                // Unreachable in practice: run()'s .recv handler skips a conn
++                // already in .handover, and processHTTPData only ever arrives
++                // here from .active. Left as a plain remove rather than
++                // `unreachable` so a wrong analysis degrades to a stale list
++                // entry instead of aborting a live relay.
                  .handover => self.handover_list.remove(io, conn),
              }
  
-@@ -782,7 +799,15 @@
+@@ -684,7 +718,8 @@
+                 .active => self.active_list.insert(io, conn),
+                 .keepalive => self.keepalive_list.insert(io, conn),
+                 .request => self.request_list.insert(conn),
+-                .handover => self.handover_list.insert(io, conn),
++                // Published by the caller once _mut is released; see swapList.
++                .handover => {},
+             }
+         }
+ 
+@@ -782,7 +817,15 @@
  
              while (c) |conn| {
                  c = conn.next;
@@ -91,7 +128,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  switch (http_conn.handover) {
                      .close, .unknown => {
                          closed_bool.* = true;
-@@ -793,7 +818,7 @@
+@@ -793,7 +836,7 @@
                          // can deliver a .recv for the freed Conn.
                          loop.remove(conn);
                          conn.close();
@@ -100,7 +137,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                      },
                      .disown => {
                          // When res.disown() was called, we immediately removed
-@@ -802,14 +827,14 @@
+@@ -802,14 +845,14 @@
                          // before we get back here.
                          // https://github.com/karlseguin/http.zig/issues/129#issuecomment-3031411404
                          closed_bool.* = true;
@@ -117,7 +154,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                              continue;
                          }
  
-@@ -817,18 +842,70 @@
+@@ -817,18 +860,70 @@
  
                          const hc: *ws.HandlerConn(WSH) = @ptrCast(@alignCast(ptr));
                          conn.protocol = .{ .websocket = hc };
@@ -189,7 +226,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
          }
  
          // Entry-point of our thread pool. `thread_buf` is a thread-specific buffer
-@@ -885,10 +962,10 @@
+@@ -885,10 +980,10 @@
              if (success == false) {
                  ws_conn.close(.{ .code = 4997, .reason = "wsz" }) catch {};
                  self.websocket.cleanupConn(hc);
@@ -202,7 +239,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              } else {
                  // Release `processing` before re-arming. With EPOLLONESHOT, re-arming
                  // while still holding `processing` loses a read that arrives in the
-@@ -903,10 +980,60 @@
+@@ -903,20 +998,77 @@
                      log.debug("({f}) failed to add read event monitor: {}", .{ ws_conn.address, err });
                      ws_conn.close(.{ .code = 4998, .reason = "wsz" }) catch {};
                      self.websocket.cleanupConn(hc);
@@ -263,7 +300,16 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
          fn disown(self: *Self, conn: *Conn(WSH)) void {
              const io = self.io;
              const http_conn = conn.protocol.http;
-@@ -916,7 +1043,7 @@
+             switch (http_conn._state) {
+                 .request => self.request_list.remove(conn),
++                // Unreachable in practice: both callers (run()'s parse-error
++                // path and accept()'s errdefer) only ever hold .request or
++                // .keepalive conns, and .handover conns are released through
++                // releaseHandover instead. Left as a plain remove rather than
++                // `unreachable` so a wrong analysis degrades to a stale list
++                // entry instead of aborting a live relay. Do NOT route a
++                // handover-snapshot node here; see releaseHandover for why.
+                 .handover => self.handover_list.remove(io, conn),
                  .keepalive => self.keepalive_list.remove(io, conn),
                  .active => unreachable,
              }
@@ -272,7 +318,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              self.http_conn_pool.release(http_conn);
              self.conn_mem_pool.destroy(conn);
          }
-@@ -995,7 +1122,7 @@
+@@ -995,7 +1147,7 @@
              while (conn) |c| {
                  conn = c.next;
                  c.close();

--- a/vendor/httpz.patch
+++ b/vendor/httpz.patch
@@ -60,7 +60,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  .keepalive_list = .{},
                  .buffer_pool = buffer_pool,
                  .conn_mem_pool = conn_mem_pool,
-@@ -668,13 +678,37 @@
+@@ -668,14 +678,46 @@
          fn swapList(self: *Self, conn: *Conn(WSH), new_state: HTTPConn.State) void {
              const io = self.io;
              const http_conn = conn.protocol.http;
@@ -93,15 +93,25 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  .active => self.active_list.remove(io, conn),
                  .keepalive => self.keepalive_list.remove(io, conn),
                  .request => self.request_list.remove(conn),
+-                .handover => self.handover_list.remove(io, conn),
 +                // Unreachable in practice: run()'s .recv handler skips a conn
 +                // already in .handover, and processHTTPData only ever arrives
-+                // here from .active. Left as a plain remove rather than
-+                // `unreachable` so a wrong analysis degrades to a stale list
-+                // entry instead of aborting a live relay.
-                 .handover => self.handover_list.remove(io, conn),
++                // here from .active.
++                //
++                // Logged rather than removed, because remove() is the dangerous
++                // option: on a non-member it rewrites the live list's head/tail
++                // from stale prev/next, which is exactly the connection-loss and
++                // core-pinning bug releaseHandover documents. That is not a
++                // "stale entry" degradation, so doing nothing is strictly safer,
++                // and the log makes a wrong analysis observable.
++                .handover => {
++                    log.err("swapList reached the unreachable .handover state; not touching any list", .{});
++                    return;
++                },
              }
  
-@@ -684,7 +718,8 @@
+             http_conn.setState(new_state);
+@@ -684,7 +726,8 @@
                  .active => self.active_list.insert(io, conn),
                  .keepalive => self.keepalive_list.insert(io, conn),
                  .request => self.request_list.insert(conn),
@@ -111,7 +121,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              }
          }
  
-@@ -782,7 +817,15 @@
+@@ -782,7 +825,15 @@
  
              while (c) |conn| {
                  c = conn.next;
@@ -128,7 +138,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  switch (http_conn.handover) {
                      .close, .unknown => {
                          closed_bool.* = true;
-@@ -793,7 +836,7 @@
+@@ -793,7 +844,7 @@
                          // can deliver a .recv for the freed Conn.
                          loop.remove(conn);
                          conn.close();
@@ -137,7 +147,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                      },
                      .disown => {
                          // When res.disown() was called, we immediately removed
-@@ -802,14 +845,14 @@
+@@ -802,14 +853,14 @@
                          // before we get back here.
                          // https://github.com/karlseguin/http.zig/issues/129#issuecomment-3031411404
                          closed_bool.* = true;
@@ -154,7 +164,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                              continue;
                          }
  
-@@ -817,18 +860,70 @@
+@@ -817,18 +868,70 @@
  
                          const hc: *ws.HandlerConn(WSH) = @ptrCast(@alignCast(ptr));
                          conn.protocol = .{ .websocket = hc };
@@ -226,7 +236,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
          }
  
          // Entry-point of our thread pool. `thread_buf` is a thread-specific buffer
-@@ -885,10 +980,10 @@
+@@ -885,10 +988,10 @@
              if (success == false) {
                  ws_conn.close(.{ .code = 4997, .reason = "wsz" }) catch {};
                  self.websocket.cleanupConn(hc);
@@ -239,7 +249,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              } else {
                  // Release `processing` before re-arming. With EPOLLONESHOT, re-arming
                  // while still holding `processing` loses a read that arrives in the
-@@ -903,20 +998,77 @@
+@@ -903,20 +1006,77 @@
                      log.debug("({f}) failed to add read event monitor: {}", .{ ws_conn.address, err });
                      ws_conn.close(.{ .code = 4998, .reason = "wsz" }) catch {};
                      self.websocket.cleanupConn(hc);
@@ -302,14 +312,15 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              const http_conn = conn.protocol.http;
              switch (http_conn._state) {
                  .request => self.request_list.remove(conn),
+-                .handover => self.handover_list.remove(io, conn),
 +                // Unreachable in practice: both callers (run()'s parse-error
 +                // path and accept()'s errdefer) only ever hold .request or
 +                // .keepalive conns, and .handover conns are released through
-+                // releaseHandover instead. Left as a plain remove rather than
-+                // `unreachable` so a wrong analysis degrades to a stale list
-+                // entry instead of aborting a live relay. Do NOT route a
-+                // handover-snapshot node here; see releaseHandover for why.
-                 .handover => self.handover_list.remove(io, conn),
++                // releaseHandover instead. Do NOT route a handover-snapshot node
++                // here: remove() on a non-member rewrites the live list's
++                // head/tail from stale prev/next, the connection-loss bug
++                // releaseHandover documents, so this arm removes nothing.
++                .handover => log.err("disown reached the unreachable .handover state; not touching any list", .{}),
                  .keepalive => self.keepalive_list.remove(io, conn),
                  .active => unreachable,
              }
@@ -318,12 +329,60 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              self.http_conn_pool.release(http_conn);
              self.conn_mem_pool.destroy(conn);
          }
-@@ -995,7 +1147,7 @@
+@@ -995,7 +1155,8 @@
              while (conn) |c| {
                  conn = c.next;
                  c.close();
 -                self.len -= 1;
 +                self.releaseSlot();
++
                  self.http_conn_pool.release(c.protocol.http);
                  self.conn_mem_pool.destroy(c);
              }
+@@ -1509,6 +1670,38 @@
+     }
+ 
+     fn release(self: *HTTPConnPool, conn: *HTTPConn) void {
++        const io = self.io;
++
++        // Recycling an HTTPConn while a thread still holds its lock is a
++        // use-after-free: that thread's later _mut.unlock writes into an object
++        // returned to this pool or destroyed. Reproduced as a panic in
++        // Mutex.unlock ("switch on corrupt value"); in ReleaseFast there is no
++        // check, and since accept() does not re-init _mut, a fresh connection
++        // can inherit a stolen lock and end up with two threads inside
++        // swapListLocked for one conn.
++        //
++        // swapList holds _mut across its keepalive and request inserts, both of
++        // which publish the conn to the event-loop thread, so that thread can
++        // reach a free before the worker's deferred unlock lands. It gets there
++        // by three routes (disown, closeList, releaseHandover) and fencing them
++        // individually already missed one, so the wait lives here instead: this
++        // is the single point every free funnels through.
++        //
++        // Waiting for the lock is what makes it safe; the log is what makes the
++        // ordering violation attributable, since this race is not reachable from
++        // a unit test. Deadlock-free because every caller reaches this holding
++        // no list mutex, while the worker's order is _mut then list.mut, and
++        // because this runs before self.lock() below.
++        // Debug, not error: the wait below makes this safe, so it is an expected
++        // and handled interleaving rather than a fault. Under a deliberately
++        // widened window it fired 403 times across 1800 connections, so at error
++        // level it would be pure noise in production.
++        if (conn._mut.state.load(.monotonic) != .unlocked) {
++            log.debug("HTTPConn released while its lock was still held; waiting for the holder", .{});
++        }
++        conn._mut.lockUncancelable(io);
++        conn._mut.unlock(io);
++
+         const conns = self.conns;
+         self.lock();
+         const available = self.available;
+@@ -1516,7 +1709,6 @@
+             self.unlock();
+             conn.deinit(self.allocator);
+ 
+-            const io = self.io;
+             self.http_mem_pool_mut.lockUncancelable(io);
+             self.http_mem_pool.destroy(conn);
+             self.http_mem_pool_mut.unlock(io);

--- a/vendor/httpz/src/worker.zig
+++ b/vendor/httpz/src/worker.zig
@@ -678,20 +678,37 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
         fn swapList(self: *Self, conn: *Conn(WSH), new_state: HTTPConn.State) void {
             const io = self.io;
             const http_conn = conn.protocol.http;
-            http_conn._mut.lockUncancelable(io);
-            defer http_conn._mut.unlock(io);
+            {
+                http_conn._mut.lockUncancelable(io);
+                defer http_conn._mut.unlock(io);
+                self.swapListLocked(conn, http_conn, new_state);
+            }
 
+            // Publishing to handover_list hands this conn to the event-loop
+            // thread, which may release it (releaseHandover) before this call
+            // even returns. So it MUST be the last thing that touches conn or
+            // http_conn: doing it inside the critical section above meant the
+            // deferred _mut.unlock() then wrote into an HTTPConn already
+            // returned to the pool or destroyed, which panics in Mutex.unlock
+            // with "switch on corrupt value" (reproduced) and is a silent
+            // write to recycled memory in ReleaseFast. The caller's
+            // loop.signal() afterwards deliberately touches neither.
+            if (new_state == .handover) self.handover_list.insert(io, conn);
+        }
+
+        // Everything that needs http_conn._mut held. Split out so the handover
+        // publish can happen strictly after the mutex is released.
+        fn swapListLocked(self: *Self, conn: *Conn(WSH), http_conn: *HTTPConn, new_state: HTTPConn.State) void {
+            const io = self.io;
             switch (http_conn._state) {
                 .active => self.active_list.remove(io, conn),
                 .keepalive => self.keepalive_list.remove(io, conn),
                 .request => self.request_list.remove(conn),
-                // Unreachable in practice: both callers (run()'s parse-error
-                // path and accept()'s errdefer) only ever hold .request or
-                // .keepalive conns, and .handover conns are released through
-                // releaseHandover instead. Left as a plain remove rather than
-                // `unreachable` so that a wrong analysis degrades to a stale
-                // list entry instead of aborting a live relay. Do NOT route a
-                // handover-snapshot node here; see releaseHandover for why.
+                // Unreachable in practice: run()'s .recv handler skips a conn
+                // already in .handover, and processHTTPData only ever arrives
+                // here from .active. Left as a plain remove rather than
+                // `unreachable` so a wrong analysis degrades to a stale list
+                // entry instead of aborting a live relay.
                 .handover => self.handover_list.remove(io, conn),
             }
 
@@ -701,7 +718,8 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 .active => self.active_list.insert(io, conn),
                 .keepalive => self.keepalive_list.insert(io, conn),
                 .request => self.request_list.insert(conn),
-                .handover => self.handover_list.insert(io, conn),
+                // Published by the caller once _mut is released; see swapList.
+                .handover => {},
             }
         }
 
@@ -1039,6 +1057,13 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             const http_conn = conn.protocol.http;
             switch (http_conn._state) {
                 .request => self.request_list.remove(conn),
+                // Unreachable in practice: both callers (run()'s parse-error
+                // path and accept()'s errdefer) only ever hold .request or
+                // .keepalive conns, and .handover conns are released through
+                // releaseHandover instead. Left as a plain remove rather than
+                // `unreachable` so a wrong analysis degrades to a stale list
+                // entry instead of aborting a live relay. Do NOT route a
+                // handover-snapshot node here; see releaseHandover for why.
                 .handover => self.handover_list.remove(io, conn),
                 .keepalive => self.keepalive_list.remove(io, conn),
                 .active => unreachable,

--- a/vendor/httpz/src/worker.zig
+++ b/vendor/httpz/src/worker.zig
@@ -706,10 +706,18 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 .request => self.request_list.remove(conn),
                 // Unreachable in practice: run()'s .recv handler skips a conn
                 // already in .handover, and processHTTPData only ever arrives
-                // here from .active. Left as a plain remove rather than
-                // `unreachable` so a wrong analysis degrades to a stale list
-                // entry instead of aborting a live relay.
-                .handover => self.handover_list.remove(io, conn),
+                // here from .active.
+                //
+                // Logged rather than removed, because remove() is the dangerous
+                // option: on a non-member it rewrites the live list's head/tail
+                // from stale prev/next, which is exactly the connection-loss and
+                // core-pinning bug releaseHandover documents. That is not a
+                // "stale entry" degradation, so doing nothing is strictly safer,
+                // and the log makes a wrong analysis observable.
+                .handover => {
+                    log.err("swapList reached the unreachable .handover state; not touching any list", .{});
+                    return;
+                },
             }
 
             http_conn.setState(new_state);
@@ -1060,11 +1068,11 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 // Unreachable in practice: both callers (run()'s parse-error
                 // path and accept()'s errdefer) only ever hold .request or
                 // .keepalive conns, and .handover conns are released through
-                // releaseHandover instead. Left as a plain remove rather than
-                // `unreachable` so a wrong analysis degrades to a stale list
-                // entry instead of aborting a live relay. Do NOT route a
-                // handover-snapshot node here; see releaseHandover for why.
-                .handover => self.handover_list.remove(io, conn),
+                // releaseHandover instead. Do NOT route a handover-snapshot node
+                // here: remove() on a non-member rewrites the live list's
+                // head/tail from stale prev/next, the connection-loss bug
+                // releaseHandover documents, so this arm removes nothing.
+                .handover => log.err("disown reached the unreachable .handover state; not touching any list", .{}),
                 .keepalive => self.keepalive_list.remove(io, conn),
                 .active => unreachable,
             }
@@ -1148,6 +1156,7 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 conn = c.next;
                 c.close();
                 self.releaseSlot();
+
                 self.http_conn_pool.release(c.protocol.http);
                 self.conn_mem_pool.destroy(c);
             }
@@ -1661,6 +1670,38 @@ const HTTPConnPool = struct {
     }
 
     fn release(self: *HTTPConnPool, conn: *HTTPConn) void {
+        const io = self.io;
+
+        // Recycling an HTTPConn while a thread still holds its lock is a
+        // use-after-free: that thread's later _mut.unlock writes into an object
+        // returned to this pool or destroyed. Reproduced as a panic in
+        // Mutex.unlock ("switch on corrupt value"); in ReleaseFast there is no
+        // check, and since accept() does not re-init _mut, a fresh connection
+        // can inherit a stolen lock and end up with two threads inside
+        // swapListLocked for one conn.
+        //
+        // swapList holds _mut across its keepalive and request inserts, both of
+        // which publish the conn to the event-loop thread, so that thread can
+        // reach a free before the worker's deferred unlock lands. It gets there
+        // by three routes (disown, closeList, releaseHandover) and fencing them
+        // individually already missed one, so the wait lives here instead: this
+        // is the single point every free funnels through.
+        //
+        // Waiting for the lock is what makes it safe; the log is what makes the
+        // ordering violation attributable, since this race is not reachable from
+        // a unit test. Deadlock-free because every caller reaches this holding
+        // no list mutex, while the worker's order is _mut then list.mut, and
+        // because this runs before self.lock() below.
+        // Debug, not error: the wait below makes this safe, so it is an expected
+        // and handled interleaving rather than a fault. Under a deliberately
+        // widened window it fired 403 times across 1800 connections, so at error
+        // level it would be pure noise in production.
+        if (conn._mut.state.load(.monotonic) != .unlocked) {
+            log.debug("HTTPConn released while its lock was still held; waiting for the holder", .{});
+        }
+        conn._mut.lockUncancelable(io);
+        conn._mut.unlock(io);
+
         const conns = self.conns;
         self.lock();
         const available = self.available;
@@ -1668,7 +1709,6 @@ const HTTPConnPool = struct {
             self.unlock();
             conn.deinit(self.allocator);
 
-            const io = self.io;
             self.http_mem_pool_mut.lockUncancelable(io);
             self.http_mem_pool.destroy(conn);
             self.http_mem_pool_mut.unlock(io);


### PR DESCRIPTION
Fixes a use-after-free of a connection's mutex that aborts the relay. Pre-existing and identical upstream; unchanged by the recent handover-list work.

## The bug

`swapList` runs on a thread-pool thread and holds `http_conn._mut` across its whole body, including the final `handover_list.insert`. That insert is the *publish*: it makes the connection visible to the event-loop thread, which can snapshot the handover list and release the connection (`releaseHandover` returns the `HTTPConn` to its pool or destroys it) at any moment afterwards.

`handover_list.insert` releases the list mutex before `swapList`'s deferred `_mut.unlock` runs. So:

```
worker:  handover_list.insert(conn) returns, list mutex released
loop:    snapshot sees conn, releaseHandover pools/destroys http_conn
worker:  http_conn._mut.unlock(io)      <- writes into an object it no longer owns
```

Nothing synchronizes those: `processSignal` never takes `_mut`. Reaching the window needs the loop already awake on some *other* connection's signal, since this connection's own signal is sent after `swapList` returns. With several thread-pool threads that is routine.

## Reproduced, not inferred

Compiled a probe into `HTTPConnPool.release` that reads `conn._mut.state` and reports when the pool takes ownership of a still-locked mutex, then widened the window with a 2ms delay between the insert and the unlock to make the interleaving reliable. Load was 2000 interleaved WebSocket upgrades and `Connection: close` requests.

| | probe hits | panics | relay |
|---|---|---|---|
| before | 24 | yes | **aborted, core dumped** |
| after | 0 | 0 | alive |

The panic lands exactly where the analysis predicts, in `Mutex.unlock`:

```
thread N panic: switch on corrupt value
  std/Io.zig:1642 in swapList          <- switch (m.state.swap(.unlocked, .release))
  vendor/httpz/src/worker.zig:956 in processHTTPData
      self.swapList(conn, .handover);
```

"switch on corrupt value" is the mutex memory no longer holding a valid `State`, because the `HTTPConn` was recycled underneath it. In ReleaseSafe that is an abort, so a remote peer driving handover churn can restart the relay; in ReleaseFast (the release build) there is no check and it is a silent write into recycled memory.

**Honest limit on this evidence:** the 2ms delay is what makes it reproducible. It proves the mechanism and the consequence, not the natural rate. An earlier run without the delay produced zero hits, but its load generator was too slow to create meaningful handover churn, so that is not evidence of rarity either.

## The fix

Publishing is now the last thing that touches the connection, and happens after `_mut` is released. The locked region moves into `swapListLocked`; `swapList` releases the mutex and only then inserts into `handover_list`. The caller's following `loop.signal()` deliberately touches neither `conn` nor `http_conn`, so it stays safe.

The gap this opens, between the unlock and the insert, is harmless: the connection is in no list and its state is already `.handover`, which is exactly what `run()`'s `.recv` handler checks for and skips.

## Also here

Corrects a comment I misplaced in #181. It was meant for `disown()` but a first-match replacement put it on `swapList`, where its reasoning ("both callers: run()'s parse-error path and accept()'s errdefer") describes `disown`'s callers, not `swapList`'s. Both switches now carry the reasoning that actually applies to them.

## Verification

`zig build test` 65/65, handover-leak test 6/6, protocol 45/45, concurrency 2/2 at 200 connections, `verify-vendored-httpz.sh` clean, zero panics or corruption in any relay log.

## Review follow-up: the first fix was incomplete

Both reviews independently found that moving the handover publish fixed only one of two paths, and my own repro confirmed it. `swapList` also publishes `.keepalive` (and `.request`) from **inside** the critical section, and the event-loop thread reaches those through `disown()` and `closeList()`, neither of which takes `_mut`. So the same use-after-free survived.

Reproduced it the same way, with `http_keepalive_timeout_s = 0` so every keepalive conn expires on insert: **57 probe hits and the relay aborted**, same panic, now from the `.keepalive` call site.

Hoisting the keepalive insert the way the handover one was hoisted is **not** a valid fix, and both reviews said so independently. `run()`'s `.recv` skips a `.handover` conn but not a `.keepalive` one, so a gap with `.keepalive` state and no list membership would let a pipelined request drive `keepalive_list.remove` on a non-member, nulling `head` and `tail` and wiping the live list. That trades a rare use-after-free for a reachable list wipe.

So the wait goes where every free funnels through: `HTTPConnPool.release` takes and releases `_mut` before recycling, which makes it impossible for a call site to miss. I know that matters because I first fenced only `closeList` and the relay still crashed through `disown`.

Verified with both windows widened and mixed load including pipelined parse errors, which is what drives the `disown` path:

| | violations | panics | relay |
|---|---|---|---|
| fence in `closeList` only | 5 | 1 | aborted |
| fence in `release()` | 403 caught and waited on | 0 | alive |

The 403 is the fence doing its job under a deliberately widened window; it is logged at debug rather than error, since the wait makes it an expected and handled interleaving rather than a fault.

**One result in this series was invalid and I am not counting it:** an intermediate run reported a crash, but the build had failed on a shadowed `io` binding and the test had silently run the previous binary. The runs above are gated on the build succeeding.

Also corrected here, per both reviews: my "degrades to a stale list entry" rationale on the impossible `.handover` arms was false. `List.remove` on a non-member rewrites the live list's head and tail from stale links, which is the connection-loss and core-pinning bug fixed in #181, not a benign stale entry. Those arms now log and touch no list, which is what actually degrades safely.

Re-verified on the final tree: `zig build test` 65/65, handover-leak 6/6, protocol 45/45, concurrency 2/2, vendor integrity clean, zero panics.
