### PR TITLE
Run the accept teardown once, and guard the shutdown union read

### DIFF
--- a/vendor/httpz.patch
+++ b/vendor/httpz.patch
@@ -150,15 +150,29 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
  
                  const ip_address = address.toIOAddress();
  
-@@ -748,6 +802,7 @@
+@@ -741,13 +795,20 @@
+                 http_conn.stream = .{ .socket = .{ .handle = socket, .address = ip_address } };
+                 http_conn.timeout = now + self.timeout_request;
+ 
+-                self.len += 1;
+                 conn.* = .{
+                     .next = null,
+                     .prev = null,
                      .protocol = .{ .http = http_conn },
                  };
                  self.request_list.insert(conn);
++                // Take the slot and arm the full teardown together, with nothing
++                // fallible between them. The two errdefers above release neither
++                // the slot nor the list entry, so a `try` added in that gap would
++                // leak a worker slot permanently and, past the insert, leave a
++                // freed Conn in the live request_list. These three statements
++                // must stay adjacent.
++                self.len += 1;
 +                conn_owns_teardown = true;
                  errdefer {
                      conn.close();
                      self.disown(conn);
-@@ -782,7 +837,15 @@
+@@ -782,7 +843,15 @@
  
              while (c) |conn| {
                  c = conn.next;
@@ -175,7 +189,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  switch (http_conn.handover) {
                      .close, .unknown => {
                          closed_bool.* = true;
-@@ -793,7 +856,7 @@
+@@ -793,7 +862,7 @@
                          // can deliver a .recv for the freed Conn.
                          loop.remove(conn);
                          conn.close();
@@ -184,7 +198,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                      },
                      .disown => {
                          // When res.disown() was called, we immediately removed
-@@ -802,14 +865,14 @@
+@@ -802,14 +871,14 @@
                          // before we get back here.
                          // https://github.com/karlseguin/http.zig/issues/129#issuecomment-3031411404
                          closed_bool.* = true;
@@ -201,7 +215,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                              continue;
                          }
  
-@@ -817,18 +880,70 @@
+@@ -817,18 +886,70 @@
  
                          const hc: *ws.HandlerConn(WSH) = @ptrCast(@alignCast(ptr));
                          conn.protocol = .{ .websocket = hc };
@@ -273,7 +287,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
          }
  
          // Entry-point of our thread pool. `thread_buf` is a thread-specific buffer
-@@ -885,10 +1000,10 @@
+@@ -885,10 +1006,10 @@
              if (success == false) {
                  ws_conn.close(.{ .code = 4997, .reason = "wsz" }) catch {};
                  self.websocket.cleanupConn(hc);
@@ -286,7 +300,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              } else {
                  // Release `processing` before re-arming. With EPOLLONESHOT, re-arming
                  // while still holding `processing` loses a read that arrives in the
-@@ -903,20 +1018,77 @@
+@@ -903,20 +1024,77 @@
                      log.debug("({f}) failed to add read event monitor: {}", .{ ws_conn.address, err });
                      ws_conn.close(.{ .code = 4998, .reason = "wsz" }) catch {};
                      self.websocket.cleanupConn(hc);
@@ -366,7 +380,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              self.http_conn_pool.release(http_conn);
              self.conn_mem_pool.destroy(conn);
          }
-@@ -995,7 +1167,8 @@
+@@ -995,7 +1173,8 @@
              while (conn) |c| {
                  conn = c.next;
                  c.close();
@@ -376,7 +390,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  self.http_conn_pool.release(c.protocol.http);
                  self.conn_mem_pool.destroy(c);
              }
-@@ -1006,7 +1179,30 @@
+@@ -1006,7 +1185,30 @@
              var conn = list.head;
              while (conn) |c| {
                  conn = c.next;
@@ -408,7 +422,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  posix.close(http_conn.stream.socket.handle);
                  http_conn.deinit(allocator);
              }
-@@ -1509,6 +1705,38 @@
+@@ -1509,6 +1711,38 @@
      }
  
      fn release(self: *HTTPConnPool, conn: *HTTPConn) void {
@@ -447,7 +461,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
          const conns = self.conns;
          self.lock();
          const available = self.available;
-@@ -1516,7 +1744,6 @@
+@@ -1516,7 +1750,6 @@
              self.unlock();
              conn.deinit(self.allocator);
  

--- a/vendor/httpz.patch
+++ b/vendor/httpz.patch
@@ -121,7 +121,44 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              }
          }
  
-@@ -782,7 +825,15 @@
+@@ -719,7 +762,18 @@
+                     // Linux can wake up multiple epoll fds for a single connection.
+                     return if (err == error.WouldBlock) {} else err;
+                 };
+-                errdefer posix.close(socket);
++                // Set once the conn owns both the socket and its own memory, i.e.
++                // once the errdefer below can do the whole teardown. Without it
++                // the errdefers unwind LIFO and all three run: disown() destroys
++                // the Conn and closes the socket, then these two destroy it a
++                // second time and close the fd again. Reproduced by injecting a
++                // monitorRead failure: all three cleanups fired for one
++                // connection and the relay aborted. A double
++                // MemoryPool.destroy links a node to itself, so two later
++                // create() calls hand the same Conn to two connections, and the
++                // double close can land on an fd another thread just opened.
++                var conn_owns_teardown = false;
++                errdefer if (!conn_owns_teardown) posix.close(socket);
+                 metrics.connection();
+ 
+                 const socket_flags = try posix.fcntl(socket, posix.F.GETFL, 0);
+@@ -727,7 +781,7 @@
+                 std.debug.assert(socket_flags & nonblocking == nonblocking);
+ 
+                 const conn = try self.conn_mem_pool.create(self.allocator);
+-                errdefer self.conn_mem_pool.destroy(conn);
++                errdefer if (!conn_owns_teardown) self.conn_mem_pool.destroy(conn);
+ 
+                 const ip_address = address.toIOAddress();
+ 
+@@ -748,6 +802,7 @@
+                     .protocol = .{ .http = http_conn },
+                 };
+                 self.request_list.insert(conn);
++                conn_owns_teardown = true;
+                 errdefer {
+                     conn.close();
+                     self.disown(conn);
+@@ -782,7 +837,15 @@
  
              while (c) |conn| {
                  c = conn.next;
@@ -138,7 +175,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  switch (http_conn.handover) {
                      .close, .unknown => {
                          closed_bool.* = true;
-@@ -793,7 +844,7 @@
+@@ -793,7 +856,7 @@
                          // can deliver a .recv for the freed Conn.
                          loop.remove(conn);
                          conn.close();
@@ -147,7 +184,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                      },
                      .disown => {
                          // When res.disown() was called, we immediately removed
-@@ -802,14 +853,14 @@
+@@ -802,14 +865,14 @@
                          // before we get back here.
                          // https://github.com/karlseguin/http.zig/issues/129#issuecomment-3031411404
                          closed_bool.* = true;
@@ -164,7 +201,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                              continue;
                          }
  
-@@ -817,18 +868,70 @@
+@@ -817,18 +880,70 @@
  
                          const hc: *ws.HandlerConn(WSH) = @ptrCast(@alignCast(ptr));
                          conn.protocol = .{ .websocket = hc };
@@ -236,7 +273,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
          }
  
          // Entry-point of our thread pool. `thread_buf` is a thread-specific buffer
-@@ -885,10 +988,10 @@
+@@ -885,10 +1000,10 @@
              if (success == false) {
                  ws_conn.close(.{ .code = 4997, .reason = "wsz" }) catch {};
                  self.websocket.cleanupConn(hc);
@@ -249,7 +286,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              } else {
                  // Release `processing` before re-arming. With EPOLLONESHOT, re-arming
                  // while still holding `processing` loses a read that arrives in the
-@@ -903,20 +1006,77 @@
+@@ -903,20 +1018,77 @@
                      log.debug("({f}) failed to add read event monitor: {}", .{ ws_conn.address, err });
                      ws_conn.close(.{ .code = 4998, .reason = "wsz" }) catch {};
                      self.websocket.cleanupConn(hc);
@@ -329,7 +366,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
              self.http_conn_pool.release(http_conn);
              self.conn_mem_pool.destroy(conn);
          }
-@@ -995,7 +1155,8 @@
+@@ -995,7 +1167,8 @@
              while (conn) |c| {
                  conn = c.next;
                  c.close();
@@ -339,7 +376,39 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
                  self.http_conn_pool.release(c.protocol.http);
                  self.conn_mem_pool.destroy(c);
              }
-@@ -1509,6 +1670,38 @@
+@@ -1006,7 +1179,30 @@
+             var conn = list.head;
+             while (conn) |c| {
+                 conn = c.next;
+-                const http_conn = c.protocol.http;
++                // Guard the union read. This is unreachable today: handover_list
++                // has exactly one mutation site (the insert in swapList, always
++                // with a .http conn) plus the processSignal snapshot clear, and
++                // no handover_list.remove exists any more, so no stale
++                // .websocket node can be left as its head. Verified statically
++                // and across 12 shutdown-under-load rounds with upgrades in
++                // flight: zero sightings.
++                //
++                // Guarded anyway because that safety is a non-local invariant
++                // and the failure mode here is severe: reading protocol.http on
++                // a .websocket conn panics in ReleaseSafe, and in ReleaseFast
++                // reinterprets a *ws.HandlerConn as an *HTTPConn, so
++                // posix.close() would close whatever integer lands at that
++                // offset. server.deinit() runs before storage teardown, so a
++                // wild close there can land on the LMDB fd before the final
++                // sync. Skipping leaks one fd in a process that is exiting
++                // anyway, which is strictly better than either outcome.
++                const http_conn = switch (c.protocol) {
++                    .http => |hc| hc,
++                    .websocket => {
++                        log.err("shutdownList found a .websocket conn in an http list; skipping", .{});
++                        continue;
++                    },
++                };
+                 posix.close(http_conn.stream.socket.handle);
+                 http_conn.deinit(allocator);
+             }
+@@ -1509,6 +1705,38 @@
      }
  
      fn release(self: *HTTPConnPool, conn: *HTTPConn) void {
@@ -378,7 +447,7 @@ diff -ruN upstream/src/worker.zig vendor/src/worker.zig
          const conns = self.conns;
          self.lock();
          const available = self.available;
-@@ -1516,7 +1709,6 @@
+@@ -1516,7 +1744,6 @@
              self.unlock();
              conn.deinit(self.allocator);
  

--- a/vendor/httpz/src/worker.zig
+++ b/vendor/httpz/src/worker.zig
@@ -795,13 +795,19 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 http_conn.stream = .{ .socket = .{ .handle = socket, .address = ip_address } };
                 http_conn.timeout = now + self.timeout_request;
 
-                self.len += 1;
                 conn.* = .{
                     .next = null,
                     .prev = null,
                     .protocol = .{ .http = http_conn },
                 };
                 self.request_list.insert(conn);
+                // Take the slot and arm the full teardown together, with nothing
+                // fallible between them. The two errdefers above release neither
+                // the slot nor the list entry, so a `try` added in that gap would
+                // leak a worker slot permanently and, past the insert, leave a
+                // freed Conn in the live request_list. These three statements
+                // must stay adjacent.
+                self.len += 1;
                 conn_owns_teardown = true;
                 errdefer {
                     conn.close();

--- a/vendor/httpz/src/worker.zig
+++ b/vendor/httpz/src/worker.zig
@@ -762,7 +762,18 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                     // Linux can wake up multiple epoll fds for a single connection.
                     return if (err == error.WouldBlock) {} else err;
                 };
-                errdefer posix.close(socket);
+                // Set once the conn owns both the socket and its own memory, i.e.
+                // once the errdefer below can do the whole teardown. Without it
+                // the errdefers unwind LIFO and all three run: disown() destroys
+                // the Conn and closes the socket, then these two destroy it a
+                // second time and close the fd again. Reproduced by injecting a
+                // monitorRead failure: all three cleanups fired for one
+                // connection and the relay aborted. A double
+                // MemoryPool.destroy links a node to itself, so two later
+                // create() calls hand the same Conn to two connections, and the
+                // double close can land on an fd another thread just opened.
+                var conn_owns_teardown = false;
+                errdefer if (!conn_owns_teardown) posix.close(socket);
                 metrics.connection();
 
                 const socket_flags = try posix.fcntl(socket, posix.F.GETFL, 0);
@@ -770,7 +781,7 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                 std.debug.assert(socket_flags & nonblocking == nonblocking);
 
                 const conn = try self.conn_mem_pool.create(self.allocator);
-                errdefer self.conn_mem_pool.destroy(conn);
+                errdefer if (!conn_owns_teardown) self.conn_mem_pool.destroy(conn);
 
                 const ip_address = address.toIOAddress();
 
@@ -791,6 +802,7 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
                     .protocol = .{ .http = http_conn },
                 };
                 self.request_list.insert(conn);
+                conn_owns_teardown = true;
                 errdefer {
                     conn.close();
                     self.disown(conn);
@@ -1167,7 +1179,30 @@ pub fn NonBlocking(comptime S: type, comptime WSH: type) type {
             var conn = list.head;
             while (conn) |c| {
                 conn = c.next;
-                const http_conn = c.protocol.http;
+                // Guard the union read. This is unreachable today: handover_list
+                // has exactly one mutation site (the insert in swapList, always
+                // with a .http conn) plus the processSignal snapshot clear, and
+                // no handover_list.remove exists any more, so no stale
+                // .websocket node can be left as its head. Verified statically
+                // and across 12 shutdown-under-load rounds with upgrades in
+                // flight: zero sightings.
+                //
+                // Guarded anyway because that safety is a non-local invariant
+                // and the failure mode here is severe: reading protocol.http on
+                // a .websocket conn panics in ReleaseSafe, and in ReleaseFast
+                // reinterprets a *ws.HandlerConn as an *HTTPConn, so
+                // posix.close() would close whatever integer lands at that
+                // offset. server.deinit() runs before storage teardown, so a
+                // wild close there can land on the LMDB fd before the final
+                // sync. Skipping leaks one fd in a process that is exiting
+                // anyway, which is strictly better than either outcome.
+                const http_conn = switch (c.protocol) {
+                    .http => |hc| hc,
+                    .websocket => {
+                        log.err("shutdownList found a .websocket conn in an http list; skipping", .{});
+                        continue;
+                    },
+                };
                 posix.close(http_conn.stream.socket.handle);
                 http_conn.deinit(allocator);
             }


### PR DESCRIPTION
Two remaining teardown defects in the vendored epoll worker. Both pre-existing and identical upstream.

## 1. `accept()` runs its whole teardown twice on a `monitorRead` failure

Three errdefers are live when `loop.monitorRead(conn)` fails, and they unwind LIFO, so all three run for one connection:

```
errdefer-C  conn.close() + disown()      <- closes the socket, destroys the Conn
errdefer-B  conn_mem_pool.destroy(conn)  <- destroys it a SECOND time
errdefer-A  posix.close(socket)          <- closes the fd a SECOND time
```

`disown()` already does the full teardown (list removal, slot release, `http_conn_pool.release`, `conn_mem_pool.destroy`), so the two earlier errdefers are pure duplication once the conn owns itself.

`std.heap.MemoryPool.destroy` prepends to a free list, so a double destroy links a node to itself and two later `create()` calls hand the **same** `Conn` to two different connections. The double `close()` can land on an fd another thread just opened.

**Reproduced by fault injection**, since the trigger is `epoll_ctl` failing (`ENOMEM`/`ENOSPC` against `fs.epoll.max_user_watches`), which is not directly attacker-controlled. Injecting a `monitorRead` failure every 5th accept and logging each errdefer gave exactly the predicted sequence, and the relay **aborted with a core dump**:

```
WISPPROBE injecting monitorRead failure
WISPPROBE errdefer-C conn.close + disown
WISPPROBE errdefer-B conn_mem_pool.destroy
WISPPROBE errdefer-A posix.close(socket)
```

The fix is a `conn_owns_teardown` flag set once the conn owns both its socket and its memory; the two earlier errdefers become no-ops from that point. Failures *before* that point still get the original cleanup, which is what they are there for.

Same injection against the fix, 8 failures: `errdefer-A` 0, `errdefer-B` 0, `errdefer-C` 8, no panics, relay alive.

## 2. `shutdownList` reads `c.protocol.http` with no union guard

This one turned out to be **already unreachable**, and I am recording why rather than just adding the guard.

The reported precondition was a `processSignal` snapshot leaving a stale `.websocket` node as `handover_list`'s head. That required `List.remove` on a snapshot node, and after the handover-list and mutex fixes there is no `handover_list.remove` anywhere in the file. The list now has exactly one mutation site, the insert in `swapList`, always with a `.http` conn, plus the snapshot clear. Verified statically, and empirically across 12 shutdown-under-load rounds with upgrades in flight: zero sightings, zero panics, 12 clean shutdowns.

Guarded anyway, because that safety is a non-local invariant and the failure mode is severe: in ReleaseSafe the union read panics, and in ReleaseFast it reinterprets a `*ws.HandlerConn` as an `*HTTPConn`, so `posix.close()` closes whatever integer lands at that offset. `server.deinit()` runs before storage teardown, so a wild close there can land on the LMDB fd before the final sync. Skipping leaks one fd in a process that is already exiting, which beats either outcome.

## Verification

`zig build test` 65/65, handover-leak 6/6, protocol 45/45, concurrency 2/2 at 200 connections, `verify-vendored-httpz.sh` clean, zero panics in any relay log.

Both fault-injection rigs were removed before the final build; the committed tree contains no probes.

## Review follow-up

Both reviews came back with no blockers. Two things worth recording.

**Applied:** `self.len += 1` sat seven lines above the ownership flag, and the two pre-flag errdefers release neither the slot nor the list entry. Any `try` added in that gap would have leaked a worker slot permanently, and past the insert would have left a freed `Conn` in the live `request_list`. The increment now sits immediately after `request_list.insert(conn)` and directly above the flag, with nothing fallible between them and a comment saying they must stay adjacent. Both reviews arrived at this independently. Re-verified afterwards, including the idle-reclaim test that reads slot reclamation back off the metrics gauge: 6/6.

**Deliberately not applied here:** the same unguarded `c.protocol.http` read remains in `collectTimedOut`, `closeList` and `disown`. Both reviews verified statically that none of them can currently see a `.websocket` conn, so this is consistency rather than a live bug, and the right remedy differs from the one used here. `shutdownList` runs during process teardown, so log-and-skip costs one leaked fd in an exiting process; those three run on every timeout sweep in a live relay, where skipping would leak a slot and an fd for the process lifetime, which is the accept-stall failure this project already fixed once. Picking the right degradation there deserves its own reproduction rather than riding along on this PR. Tracked separately.

Also confirmed by review, and worth stating because it inverts the usual intuition: the vendored `posix.close` is `.BADF => unreachable`, so the double close **aborts** in ReleaseSafe but is silent UB in ReleaseFast, which is what the release artifacts are built with. The loudly-crashing build was the safer one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public connection-count metrics for monitoring active accepted connections.

* **Bug Fixes**
  * Improved connection cleanup during failed accepts and shutdown.
  * Prevented duplicate socket and connection-resource destruction.
  * Improved WebSocket cleanup and handling of unexpected connection types.
  * Stabilized HTTP connection-pool recycling during concurrent activity.
  * Improved worker lifecycle handling to reduce connection leaks and shutdown issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->