### PR TITLE
Release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-08-12
+
+Three ways a remote peer could crash, wedge or confuse the relay, all in the
+connection lifecycle, plus a packaging build that had been broken since 0.5.15.
+Every fix here was reproduced against a running relay before it was written, and
+each is covered by a test or an invariant check that fails without it.
+
 ### Fixed
 
 - A connection handed over in the same batch as another could be dropped from
@@ -20,6 +27,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   authentication by interleaving WebSocket upgrades with requests that end in a
   close. Measured on the unfixed build: 42 leaked descriptors and a core pinned
   at 99.6% after the load stopped (#181)
+
+- A connection could be recycled while another thread still held its lock, so
+  that thread then wrote into an object it no longer owned. The worker published
+  a connection to the event loop while still inside the critical section, and
+  the loop could free it before the worker's unlock landed. On a build with
+  safety checks this aborts the process; on the release build it is a silent
+  write into recycled memory, which can leave two live sockets sharing one
+  connection record and send a reply to the wrong client. Affected both the
+  handover and the keepalive paths (#183)
+
+- A failed connection setup ran its whole cleanup twice, destroying the
+  connection record and closing the socket a second time each. A double destroy
+  puts the same record on the free list twice, so two later connections receive
+  it and interfere with each other. Only reachable when the kernel refuses to
+  register the socket, which needs memory pressure, but the consequence is
+  memory corruption rather than a clean failure (#184)
+
+- The Nix package build had been broken since httpz was vendored in 0.5.15:
+  the offline dependency set still named a superseded WebSocket revision, so
+  `nix build` failed with "package not found", and the packaged version string
+  had been reporting 0.5.10 for two releases. Both are fixed, and CI now builds
+  the Nix package and starts the resulting binary, so this cannot break
+  unnoticed again (#182)
+
+### Changed
+
+- The vendored HTTP server is re-pinned to upstream, which has adopted the
+  connection timeout fix that was previously carried here. A sweep containing
+  both expired and surviving connections no longer drops the survivors, so they
+  time out at their own deadline instead of holding a worker slot for the life
+  of the process (#180)
 
 ## [0.6.0] - 2026-08-11
 
@@ -250,7 +288,8 @@ rolling out.
 - Import/export to JSONL format
 - Configuration via TOML file or environment variables
 
-[Unreleased]: https://github.com/privkeyio/wisp/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/privkeyio/wisp/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/privkeyio/wisp/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/privkeyio/wisp/compare/v0.5.15...v0.6.0
 [0.5.15]: https://github.com/privkeyio/wisp/compare/v0.5.14...v0.5.15
 [0.5.14]: https://github.com/privkeyio/wisp/compare/v0.5.13...v0.5.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,55 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.1] - 2026-08-12
 
-Three ways a remote peer could crash, wedge or confuse the relay, all in the
-connection lifecycle, plus a packaging build that had been broken since 0.5.15.
-Every fix here was reproduced against a running relay before it was written, and
-each is covered by a test or an invariant check that fails without it.
-
-### Fixed
-
-- A connection handed over in the same batch as another could be dropped from
-  every tracking list, leaking its slot and file descriptor and leaving the
-  worker spinning on it. The epoll worker snapshots its handover list by taking
-  the head and clearing the list, but the snapshot entries keep their links, so
-  releasing one through the general path rewrote the live list's head and tail
-  from stale pointers. Anything handed over before the next drain was then
-  unreachable by any timeout sweep, while its still-registered socket was
-  re-reported on every loop iteration. Reachable remotely without
-  authentication by interleaving WebSocket upgrades with requests that end in a
-  close. Measured on the unfixed build: 42 leaked descriptors and a core pinned
-  at 99.6% after the load stopped (#181)
-
-- A connection could be recycled while another thread still held its lock, so
-  that thread then wrote into an object it no longer owned. The worker published
-  a connection to the event loop while still inside the critical section, and
-  the loop could free it before the worker's unlock landed. On a build with
-  safety checks this aborts the process; on the release build it is a silent
-  write into recycled memory, which can leave two live sockets sharing one
-  connection record and send a reply to the wrong client. Affected both the
-  handover and the keepalive paths (#183)
-
-- A failed connection setup ran its whole cleanup twice, destroying the
-  connection record and closing the socket a second time each. A double destroy
-  puts the same record on the free list twice, so two later connections receive
-  it and interfere with each other. Only reachable when the kernel refuses to
-  register the socket, which needs memory pressure, but the consequence is
-  memory corruption rather than a clean failure (#184)
-
-- The Nix package build had been broken since httpz was vendored in 0.5.15:
-  the offline dependency set still named a superseded WebSocket revision, so
-  `nix build` failed with "package not found", and the packaged version string
-  had been reporting 0.5.10 for two releases. Both are fixed, and CI now builds
-  the Nix package and starts the resulting binary, so this cannot break
-  unnoticed again (#182)
+Two ways a remote peer could crash or wedge the relay, a third that needs the kernel to refuse a socket registration, and a packaging build that had been failing since 0.5.12.
 
 ### Changed
 
-- The vendored HTTP server is re-pinned to upstream, which has adopted the
-  connection timeout fix that was previously carried here. A sweep containing
-  both expired and surviving connections no longer drops the survivors, so they
-  time out at their own deadline instead of holding a worker slot for the life
-  of the process (#180)
+- The vendored HTTP server is re-pinned to upstream, which has now adopted the connection timeout fix wisp has carried since 0.5.15. No behavior changes for anyone running 0.6.0: this retires a local patch and picks up an upstream atomics ordering fix that the WebSocket slot reclamation relies on (#180)
+
+### Fixed
+
+- A connection handed over in the same batch as another could be dropped from every tracking list, leaking its slot and file descriptor and leaving the worker spinning on it. Anything handed over before the next drain became unreachable by any timeout sweep, while its still-registered socket was re-reported on every loop iteration. Reachable remotely without authentication by interleaving WebSocket upgrades with requests that end in a close. Measured on the unfixed build: 42 leaked descriptors and a core pinned at 99.6% after the load stopped. Covered by a new integration test that fails without the fix (#181)
+- A connection could be recycled while another thread still held its lock, so that thread then wrote into a record it no longer owned. On a build with safety checks this aborts the process; on the release build there is no such check, and a later connection can inherit a lock that is already held, which leaves two threads inside the same connection's list bookkeeping at once. Reachable remotely without authentication by driving connection churn. Affected every path that publishes a connection to the event loop while still holding its lock (#183)
+- A failed connection setup ran its whole cleanup twice, destroying the connection record and closing the socket a second time each. A double destroy links the record to itself on the free list, so later connections are handed a record that is still in use. Not directly reachable by a remote peer: it needs the kernel to refuse the socket registration, either out of memory or against the per-user watch limit (#184)
+- The Nix package build had been failing since 0.5.12, when the WebSocket dependency pin moved and the offline dependency set was not updated with it, so `nix build` stopped with "package not found". The packaged version string had also been reporting 0.5.10 since 0.5.11. Both are fixed, and CI now builds the Nix package and starts the resulting binary, so neither can break unnoticed again (#182)
 
 ## [0.6.0] - 2026-08-11
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .wisp,
-    .version = "0.6.0",
+    .version = "0.6.1",
     .fingerprint = 0xc4bdec9fe6401a8d,
     .dependencies = .{
         // websocket.zig: client for spider outbound connections and the epoll

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -20,7 +20,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "wisp";
-  version = "0.6.0"; # keep in sync with build.zig.zon .version
+  version = "0.6.1"; # keep in sync with build.zig.zon .version
   inherit src;
 
   nativeBuildInputs = [ zig_0_16 ];

--- a/scripts/verify-nix-deps.sh
+++ b/scripts/verify-nix-deps.sh
@@ -128,9 +128,9 @@ done <<< "$required_pairs"
 
 # build.zig.zon is the source of truth. Three other files carry the version by
 # hand and none of them is generated, so each can drift silently: nix/package.nix
-# did exactly that, sitting at 0.5.10 across two releases. src/nip11.zig is the
+# did exactly that, sitting at 0.5.10 across six releases. src/nip11.zig is the
 # one users see, since it is what the relay reports over the wire.
-zon_version="$(grep -oP '(?<=\.version = ")[^"]+' build.zig.zon | head -1)"
+zon_version="$(grep -oP '(?<=\.version = ")[^"]+' build.zig.zon | head -1 || true)"
 if [ -z "$zon_version" ]; then
   echo "FAIL - could not read .version from build.zig.zon"
   fail=1

--- a/scripts/verify-nix-deps.sh
+++ b/scripts/verify-nix-deps.sh
@@ -126,14 +126,30 @@ while read -r hash want; do
   fi
 done <<< "$required_pairs"
 
+# build.zig.zon is the source of truth. Three other files carry the version by
+# hand and none of them is generated, so each can drift silently: nix/package.nix
+# did exactly that, sitting at 0.5.10 across two releases. src/nip11.zig is the
+# one users see, since it is what the relay reports over the wire.
 zon_version="$(grep -oP '(?<=\.version = ")[^"]+' build.zig.zon | head -1)"
-nix_version="$(grep -oP '(?<=^  version = ")[^"]+' nix/package.nix | head -1)"
-if [ -z "$zon_version" ] || [ -z "$nix_version" ]; then
-  echo "FAIL - could not read a version from build.zig.zon ('$zon_version') or nix/package.nix ('$nix_version')"
+if [ -z "$zon_version" ]; then
+  echo "FAIL - could not read .version from build.zig.zon"
   fail=1
-elif [ "$zon_version" != "$nix_version" ]; then
-  echo "FAIL - version mismatch: build.zig.zon says '$zon_version', nix/package.nix says '$nix_version'"
-  fail=1
+else
+  check_version() { # file description extracted
+    if [ -z "$3" ]; then
+      echo "FAIL - could not read the version from $1 ($2)"
+      fail=1
+    elif [ "$3" != "$zon_version" ]; then
+      echo "FAIL - version mismatch: build.zig.zon says '$zon_version', $1 says '$3' ($2)"
+      fail=1
+    fi
+  }
+  check_version nix/package.nix "nix package version" \
+    "$(grep -oP '(?<=^  version = ")[^"]+' nix/package.nix | head -1)"
+  check_version src/main.zig "startup log line" \
+    "$(grep -oP '(?<=Wisp v)[0-9]+\.[0-9]+\.[0-9]+(?= starting)' src/main.zig | head -1)"
+  check_version src/nip11.zig "NIP-11 relay information document" \
+    "$(grep -oP '(?<=\\"version\\":\\")[^\\]+' src/nip11.zig | head -1)"
 fi
 
 [ "$fail" -eq 0 ] || exit 1

--- a/src/main.zig
+++ b/src/main.zig
@@ -157,7 +157,7 @@ pub fn main(init: std.process.Init) !void {
         return error.InvalidSyncMode;
     };
 
-    std.log.info("Wisp v0.6.0 starting", .{});
+    std.log.info("Wisp v0.6.1 starting", .{});
     std.log.info("Listening on {s}:{d}", .{ config.host, config.port });
     std.log.info("Storage: {s} (sync={s})", .{ config.storage_path, @tagName(sync_mode) });
 

--- a/src/nip11.zig
+++ b/src/nip11.zig
@@ -43,7 +43,7 @@ pub fn write(config: *const Config, nip86: *const Nip86Handler, w: anytype) !voi
 
     try w.writeAll(",\"supported_nips\":[1,2,9,11,13,16,33,40,42,45,50,51,65,70,77,86]");
     try w.writeAll(",\"software\":\"https://github.com/privkeyio/wisp\"");
-    try w.writeAll(",\"version\":\"0.6.0\"");
+    try w.writeAll(",\"version\":\"0.6.1\"");
 
     try w.writeAll(",\"limitation\":{");
     try w.print("\"max_message_length\":{d}", .{config.max_message_size});


### PR DESCRIPTION
Cuts 0.6.1. Five commits have been sitting on `main` since 0.6.0, three of which fix ways a remote peer could crash, wedge or confuse the relay.

## Why now

0.6.0 is what is currently published, and these are not cosmetic:

- **#181** connections dropped from every tracking list: 42 leaked descriptors and a core pinned at 99.6% after load stopped, reachable unauthenticated
- **#183** a connection recycled while another thread still held its lock. Aborts on a safety-checked build; on the release build a later connection can inherit an already-held lock, putting two threads in one connection's list bookkeeping. Reachable unauthenticated by driving connection churn
- **#184** connection setup running its whole cleanup twice, self-linking the record on the free list. Not directly remote: needs the kernel to refuse the socket registration
- **#182** the Nix package build, failing since 0.5.12

## Version drift, which is why this touches six files

The version lives in four places and only two of them were checked. `nix/package.nix` had already drifted, reporting 0.5.10 for two releases before #182 caught it. The other unguarded copy is the one users actually see: `src/nip11.zig` is what the relay reports over the wire.

`scripts/verify-nix-deps.sh` now checks all four against `build.zig.zon` as the source of truth. Mutation-tested by breaking each independently:

- `nix/package.nix` → caught
- `src/main.zig` (startup log) → caught
- `src/nip11.zig` (NIP-11 document) → caught

Verified over the wire rather than by reading the diff: the built relay logs `Wisp v0.6.1 starting` and answers NIP-11 with `"version":"0.6.1"`.

## Release notes

The changelog entry describes each fix in terms of what a relay operator would observe, not in terms of the internals. Where a bug behaves differently between the safety-checked and release builds, it says so, since that difference determines whether an operator sees a crash or silent corruption.

## Verification

`zig build test` 65/65, protocol suite 45/45, `verify-nix-deps.sh` and `verify-vendored-httpz.sh` both clean.

## Not blocked on upstream

Worth recording since it has come up: the relay builds from `vendor/httpz`, not from an upstream fetch, and CI gates the vendored tree against upstream plus `vendor/httpz.patch`. Whether upstream adopts these fixes changes nothing about what this release contains. Upstreaming remains worth doing to retire the cost of re-applying the patch on every re-pin, but it is not a release gate.


## Review follow-up: six factual errors in the release notes, corrected

The review was pointed at accuracy of the operator-facing text, and it found six wrong claims. Each is verified against git history, not just accepted:

| claim | reality | how checked |
|---|---|---|
| Nix build broken "since httpz was vendored in 0.5.15" | the WebSocket pin moved at **v0.5.12**, a month earlier; the stale httpz entry was inert | `git log -S` on the hash in `build.zig.zon` |
| version stale "for two releases" | **six**: v0.5.11 through v0.6.0 | `git tag --contains 424e2f0` |
| #180 fixes the timeout sweep | that shipped in **0.5.15** (#166) and is already in this changelog; #180 changes nothing for an operator on 0.6.0 | read the 0.5.15 entry |
| #183 can "leave two live sockets sharing one connection record and send a reply to the wrong client" | that is #184's mechanism, not #183's. #183's consequence is a stolen lock, so two threads end up in one connection's list bookkeeping | the #183 commit and PR |
| "each is covered by a test or an invariant check that fails without it" | true only for #181 and #182. #183 and #184 add logging that does not fail | `git show --stat` on both |
| "three ways a remote peer could crash" | two. #184 needs the kernel to refuse a registration and is not directly attacker-controlled | #184's own text |

Also corrected: #184's trigger is memory pressure **or** the per-user watch limit, not memory pressure alone.

Two non-factual fixes from the same review: bullets are now single unbroken lines matching every other entry in the file, since wrapped bullets render as ragged line breaks in a GitHub release body; and `### Changed` now precedes `### Fixed`, matching 0.6.0 and Keep a Changelog.

**And a real bug in the new script:** under `set -euo pipefail`, `zon_version="$(grep ... | head -1)"` exits the script the moment grep finds nothing, so the friendly "could not read .version" message below it was unreachable and CI would have shown a bare exit 1. Fixed and verified by breaking `build.zig.zon` deliberately: the message now prints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Released version 0.6.1 with updated application and protocol metadata.
  - Added release notes covering connection-handling improvements, packaging updates, and integration coverage.

- **Bug Fixes**
  - Improved connection handling for more reliable operation.

- **Chores**
  - Updated package versions across supported distribution formats.
  - Improved version consistency checks to catch mismatched release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->